### PR TITLE
Add client/server binary utils and integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ libtool
 ltmain.sh
 m4
 missing
+py-compile
 stamp-h1
 test-driver
 
@@ -27,3 +28,5 @@ Makefile.in
 *.a
 *.lo
 *.la
+
+*.pyc

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,3 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -Im4
 
-SUBDIRS = src util
+SUBDIRS = src util test

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,3 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -Im4
 
-SUBDIRS = src
+SUBDIRS = src util

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_CONFIG_HEADERS([config.h])
 
 AC_PROG_CXX
 AM_PROG_AR
+AM_PATH_PYTHON
 
 LT_INIT
 
@@ -37,6 +38,7 @@ PKG_CHECK_MODULES([GTEST], [gmock gtest_main])
 AC_CONFIG_FILES([
   Makefile \
   src/Makefile \
+  test/Makefile \
   util/Makefile
 ])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,8 @@ PKG_CHECK_MODULES([GTEST], [gmock gtest_main])
 
 AC_CONFIG_FILES([
   Makefile \
-  src/Makefile
+  src/Makefile \
+  util/Makefile
 ])
 AC_OUTPUT
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,0 +1,9 @@
+REGTESTS = \
+  basic_calls.py
+
+noinst_PYTHON = $(REGTESTS) \
+  charonbin.py \
+  rpcserver.py \
+  testcase.py
+
+TESTS = $(REGTESTS)

--- a/test/basic_calls.py
+++ b/test/basic_calls.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python2
+
+#   Charon - a transport system for GSP data
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests basic (non-blocking) RPC calls through Charon.
+"""
+
+import testcase
+
+
+class Methods:
+
+  methods = ["echo", "error"]
+
+  def echo (self, val):
+    return val
+
+  def error (self, msg):
+    raise RuntimeError (msg)
+
+  def doNotCall (self):
+    raise AssertionError ("invalid forwarded call")
+
+
+backend = Methods ()
+with testcase.Fixture (backend.methods) as t, \
+     t.runClient () as c:
+
+  with t.runServer (backend):
+    t.mainLogger.info ("Testing successful call forwarding...")
+    t.assertEqual (c.rpc.echo ("bla"), "bla")
+    t.expectRpcError (".*my error.*", c.rpc.error, "my error")
+
+    t.mainLogger.info ("Invalid method call...")
+    t.expectRpcError (".*METHOD_NOT_FOUND.*", c.rpc.doNotCall)
+
+  t.mainLogger.info ("Testing server reselection...")
+  with t.runServer (backend):
+    t.assertEqual (c.rpc.echo ("success"), "success")

--- a/test/charonbin.py
+++ b/test/charonbin.py
@@ -1,0 +1,150 @@
+#   Charon - a transport system for GSP data
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Python code to run charon-client and charon-server processes in a controlled
+fashion for integration testing.
+"""
+
+import jsonrpclib
+import logging
+import os
+import subprocess
+import time
+
+
+# Sleep time before we consider charon-server and charon-client connected.
+# Especially since charon-server does not have an RPC interface by itself,
+# it would not be easy to properly implement a "wait until started" function.
+STARTUP_SLEEP = 1
+
+
+class Client ():
+  """
+  A context manager that runs a charon-client process under the hood while
+  the context is active.  It tries to clean the process up afterwards.
+  """
+
+  def __init__ (self, basedir, binary, port, methods,
+                serverJid, clientJid, password):
+    """
+    Constructs the manager, which will run the charon-client binary located
+    at the given path, setting its log directory and JSON-RPC port as provided.
+    """
+
+    self.log = logging.getLogger ("charon-client")
+
+    self.basedir = basedir
+    self.binary = binary
+    self.port = port
+    self.methods = methods
+    self.serverJid = serverJid
+    self.clientJid = clientJid
+    self.password = password
+
+    self.rpcurl = "http://localhost:%d" % port
+    self.proc = None
+
+  def __enter__ (self):
+    assert self.proc is None
+
+    self.log.info ("Starting new charon-client process...")
+
+    args = [self.binary]
+    args.append ("--nodetect_server")
+    args.extend (["--port", "%d" % self.port])
+    args.extend (["--client_jid", self.clientJid])
+    args.extend (["--server_jid", self.serverJid])
+    args.extend (["--password", self.password])
+    args.extend (["--methods", ",".join (self.methods)])
+
+    envVars = dict (os.environ)
+    envVars["GLOG_log_dir"] = self.basedir
+
+    self.proc = subprocess.Popen (args, env=envVars)
+    self.rpc = self.createRpc ()
+
+    time.sleep (STARTUP_SLEEP)
+
+    return self
+
+  def __exit__ (self, exc, value, traceback):
+    assert self.proc is not None
+
+    self.log.info ("Stopping charon-client process...")
+    self.rpc._notify.stop ()
+    self.proc.wait ()
+    self.proc = None
+
+  def createRpc (self):
+    """
+    Returns a fresh JSON-RPC client connection to the process' local server.
+    """
+
+    return jsonrpclib.Server (self.rpcurl)
+
+
+class Server ():
+  """
+  A context manager that runs a charon-server process under the hood while
+  the context is active.  It tries to clean the process up afterwards.
+  """
+
+  def __init__ (self, basedir, binary, methods, backendRpcUrl,
+                serverJid, password):
+    """
+    Constructs the manager, which will run the charon-server binary located
+    at the given path, setting its log directory and other variables as given.
+    """
+
+    self.log = logging.getLogger ("charon-server")
+
+    self.basedir = basedir
+    self.binary = binary
+    self.methods = methods
+    self.backendRpcUrl = backendRpcUrl
+    self.serverJid = serverJid
+    self.password = password
+
+    self.proc = None
+
+  def __enter__ (self):
+    assert self.proc is None
+
+    self.log.info ("Starting new charon-server process...")
+
+    args = [self.binary]
+    args.extend (["--backend_rpc_url", self.backendRpcUrl])
+    args.extend (["--server_jid", self.serverJid])
+    args.extend (["--password", self.password])
+    args.extend (["--methods", ",".join (self.methods)])
+
+    envVars = dict (os.environ)
+    envVars["GLOG_log_dir"] = self.basedir
+
+    self.proc = subprocess.Popen (args, env=envVars)
+
+    time.sleep (STARTUP_SLEEP)
+
+    return self
+
+  def __exit__ (self, exc, value, traceback):
+    assert self.proc is not None
+
+    self.log.info ("Stopping charon-server process...")
+    self.proc.terminate ()
+    self.proc.wait ()
+    self.proc = None

--- a/test/rpcserver.py
+++ b/test/rpcserver.py
@@ -1,0 +1,74 @@
+#   Charon - a transport system for GSP data
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Logic for implementing test RPC servers.
+"""
+
+from jsonrpclib.SimpleJSONRPCServer import SimpleJSONRPCServer
+
+import logging
+import SocketServer
+import threading
+
+
+# Polling interval for shutdown in serve_forever.
+SHUTDOWN_POLLING_INTERVAL = 0.1
+
+
+class Server (SocketServer.ThreadingMixIn, SimpleJSONRPCServer, object):
+  """
+  JSON-RPC server for use in tests.  It forwards calls to the members of
+  a given object.  This is also a context manager, which takes care of starting
+  and stopping the server in a background thread.
+  """
+
+  def __init__ (self, addr, obj):
+    """
+    Constructs the server instance, which will listen at the given address
+    ((host, port) tuple) and call methods from obj.
+    """
+
+    super (Server, self).__init__ (addr, logRequests=False)
+
+    self.log = logging.getLogger ("rpcserver")
+    self.log.info ("Setting up test RPC server at %s:%d..." % addr)
+
+    self.methods = []
+    for nm in dir (obj):
+      fcn = getattr (obj, nm)
+      if not callable (fcn):
+        continue
+      self.log.info ("RPC method: %s" % nm)
+      self.register_function (fcn, nm)
+
+    self.loop = None
+
+  def __enter__ (self):
+    assert self.loop is None
+    self.log.info ("Starting RPC serving loop...")
+    def run ():
+      self.serve_forever (SHUTDOWN_POLLING_INTERVAL)
+    self.loop = threading.Thread (target=run)
+    self.loop.start ()
+    return self
+
+  def __exit__ (self, exc, value, traceback):
+    assert self.loop is not None
+    self.log.info ("Stopping RPC serving loop...")
+    self.shutdown ()
+    self.loop.join ()
+    self.loop = None

--- a/test/testcase.py
+++ b/test/testcase.py
@@ -1,0 +1,178 @@
+#   Charon - a transport system for GSP data
+#   Copyright (C) 2019  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Basic framework for integration tests of Charon.
+"""
+
+import charonbin
+import rpcserver
+
+from contextlib import contextmanager
+import logging
+import os
+import os.path
+import random
+import re
+import shutil
+import sys
+
+from jsonrpclib import ProtocolError
+
+
+BASE_DIR = "/tmp"
+DIR_PREFIX = "charontest"
+
+# Accounts on chat.xaya.io (XID mainnet) for use with testing.
+# See src/testutils.cpp for more details.
+TEST_ACCOUNTS = [
+  ("xmpptest1", "CkEfa5+WT2Rc5/TiMDhMynAbSJ+DY9FmE5lcWgWMRQWUBV5UQsgjiBWL302N4k"
+                "dLZYygJVBVx3vYsDNUx8xBbw27WA=="),
+  ("xmpptest2", "CkEgOEFNwRdLQ6uD543MJLSzip7mTahM1we9GDl3S5NlR49nrJ0JxcFfQmDbbF"
+                "4C4OpqSlTpx8OG6xtFjCUMLh/AGA=="),
+]
+XMPP_SERVER = "chat.xaya.io"
+
+
+class Fixture (object):
+  """
+  Context manager that sets up a basic Charon test environment.  It creates
+  a temporary data directory for logs, sets up logging itself, and provides
+  functionality to easily run a charon-client and/or charon-server based
+  on the environment and predefined test accounts.
+  """
+
+  def __init__ (self, methods):
+    self.methods = methods
+
+  def __enter__ (self):
+    randomSuffix = "%08x" % random.getrandbits (32)
+    self.basedir = os.path.join (BASE_DIR, "%s_%s" % (DIR_PREFIX, randomSuffix))
+    shutil.rmtree (self.basedir, ignore_errors=True)
+    os.mkdir (self.basedir)
+
+    logfile = os.path.join (self.basedir, "test.log")
+    logHandler = logging.FileHandler (logfile)
+    logFmt = "%(asctime)s %(name)s (%(levelname)s): %(message)s"
+    logHandler.setFormatter (logging.Formatter (logFmt))
+
+    rootLogger = logging.getLogger ()
+    rootLogger.setLevel (logging.INFO)
+    rootLogger.addHandler (logHandler)
+
+    self.log = logging.getLogger ("charontest")
+
+    mainHandler = logging.StreamHandler (sys.stderr)
+    mainHandler.setFormatter (logging.Formatter ("%(message)s"))
+
+    self.mainLogger = logging.getLogger ("main")
+    self.mainLogger.addHandler (mainHandler)
+    self.mainLogger.info ("Base directory for integration test: %s"
+                            % self.basedir)
+
+    self.nextPort = random.randint (1024, 30000)
+    self.log.info ("Using ports starting from %d" % self.nextPort)
+
+    top_builddir = os.getenv ("top_builddir")
+    if top_builddir is None:
+      top_builddir = ".."
+    self.bindir = os.path.join (top_builddir, "util")
+    self.log.info ("Using binaries from %s" % self.bindir)
+
+    return self
+
+  def __exit__ (self, exc, value, traceback):
+    if exc:
+      self.mainLogger.error ("Test failed")
+      self.log.info ("Not cleaning up base directory %s" % self.basedir)
+    else:
+      self.mainLogger.info ("Test succeeded")
+      shutil.rmtree (self.basedir, ignore_errors=True)
+
+    logging.shutdown ()
+
+  def runClient (self):
+    """
+    Returns a context manager for running a Charon client in our environment.
+    """
+
+    binary = os.path.join (self.bindir, "charon-client")
+    port = self.getNextPort ()
+
+    return charonbin.Client (self.basedir, binary, port, self.methods,
+                             self.getAccountJid (TEST_ACCOUNTS[0]),
+                             self.getAccountJid (TEST_ACCOUNTS[1]),
+                             TEST_ACCOUNTS[1][1])
+
+  @contextmanager
+  def runServer (self, obj):
+    """
+    Returns a context manager for running a Charon server in our environment.
+    It will start a fresh JSON-RPC server as backend, exposing all the members
+    of obj as methods.
+    """
+
+    binary = os.path.join (self.bindir, "charon-server")
+    port = self.getNextPort ()
+    backend = "http://localhost:%d" % port
+
+    with rpcserver.Server (("localhost", port), obj), \
+         charonbin.Server (self.basedir, binary, self.methods, backend,
+                           self.getAccountJid (TEST_ACCOUNTS[0]),
+                           TEST_ACCOUNTS[0][1]):
+      yield
+
+  def assertEqual (self, a, b):
+    """
+    Asserts that two values are equal, logging them if not.
+    """
+
+    if a == b:
+      return
+
+    self.log.error ("The value of:\n%s\n\nis not equal to:\n%s" % (a, b))
+    raise AssertionError ("%s != %s" % (a, b))
+
+  def expectRpcError (self, msgRegExp, method, *args, **kwargs):
+    """
+    Calls the method object with the given arguments, and expects that
+    an RPC error is raised matching the message.
+    """
+
+    try:
+      method (*args, **kwargs)
+      self.log.error ("Expected RPC error with message %s" % msgRegExp)
+      raise AssertionError ("expected RPC error was not raised")
+    except ProtocolError as exc:
+      self.log.info ("Caught expected RPC error: %s" % exc)
+      m = exc.args[0][1]
+      msgPattern = re.compile (msgRegExp)
+      assert msgPattern.match (m)
+
+  def getNextPort (self):
+    """
+    Returns the next port to use from our port range.
+    """
+
+    self.nextPort += 1
+    return self.nextPort - 1
+
+  def getAccountJid (self, acc):
+    """
+    Returns the JID of the given test account.
+    """
+
+    return "%s@%s" % (acc[0], XMPP_SERVER)

--- a/util/.gitignore
+++ b/util/.gitignore
@@ -1,0 +1,1 @@
+charon-server

--- a/util/.gitignore
+++ b/util/.gitignore
@@ -1,1 +1,2 @@
+charon-client
 charon-server

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -8,4 +8,8 @@ charon_server_LDADD = \
   $(top_builddir)/src/libcharon.la \
   $(JSON_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \
   $(GLOG_LIBS) $(GFLAGS_LIBS)
-charon_server_SOURCES = server.cpp
+charon_server_SOURCES = server.cpp \
+  methods.cpp
+
+noinst_HEADERS = \
+  methods.hpp

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -1,0 +1,11 @@
+bin_PROGRAMS = charon-server
+
+charon_server_CXXFLAGS = \
+  -I$(top_srcdir)/src \
+  $(JSON_CFLAGS) $(JSONRPCCLIENT_CFLAGS) $(JSONRPCSERVER_CFLAGS) \
+  $(GLOG_CFLAGS) $(GFLAGS_CFLAGS)
+charon_server_LDADD = \
+  $(top_builddir)/src/libcharon.la \
+  $(JSON_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \
+  $(GLOG_LIBS) $(GFLAGS_LIBS)
+charon_server_SOURCES = server.cpp

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -1,4 +1,15 @@
-bin_PROGRAMS = charon-server
+bin_PROGRAMS = charon-client charon-server
+
+charon_client_CXXFLAGS = \
+  -I$(top_srcdir)/src \
+  $(JSON_CFLAGS) $(JSONRPCCLIENT_CFLAGS) $(JSONRPCSERVER_CFLAGS) \
+  $(GLOG_CFLAGS) $(GFLAGS_CFLAGS)
+charon_client_LDADD = \
+  $(top_builddir)/src/libcharon.la \
+  $(JSON_LIBS) $(JSONRPCCLIENT_LIBS) $(JSONRPCSERVER_LIBS) \
+  $(GLOG_LIBS) $(GFLAGS_LIBS)
+charon_client_SOURCES = client.cpp \
+  methods.cpp
 
 charon_server_CXXFLAGS = \
   -I$(top_srcdir)/src \

--- a/util/client.cpp
+++ b/util/client.cpp
@@ -1,0 +1,220 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include "methods.hpp"
+
+#include "client.hpp"
+
+#include <json/json.h>
+#include <jsonrpccpp/server.h>
+#include <jsonrpccpp/server/connectors/httpserver.h>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <condition_variable>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <mutex>
+#include <unordered_map>
+
+namespace
+{
+
+DEFINE_string (server_jid, "", "Bare or full JID for the server");
+
+DEFINE_string (client_jid, "", "Bare or full JID for the client");
+DEFINE_string (password, "", "XMPP password for the client JID");
+
+DEFINE_int32 (port, 0, "Port for the local JSON-RPC server");
+
+DEFINE_bool (detect_server, true,
+             "Whether to run server detection immediately on start");
+
+/**
+ * Local JSON-RPC server that supports stopping via notification, but otherwise
+ * forwards calls to a given list of methods to a Charon client.
+ */
+class LocalServer : public jsonrpc::AbstractServer<LocalServer>
+{
+
+private:
+
+  /** Charon client to forward to.  */
+  charon::Client& client;
+
+  /** Mutex for stopping.  */
+  std::mutex mut;
+
+  /** Condition variable to wake up the main thread when stopped.  */
+  std::condition_variable cv;
+
+  /** Set to true when we should stop running.  */
+  bool shouldStop;
+
+  /**
+   * Handler method for the stop notification.
+   */
+  void
+  stop (const Json::Value& params)
+  {
+    std::lock_guard<std::mutex> lock(mut);
+    shouldStop = true;
+    cv.notify_all ();
+  }
+
+  /**
+   * Dummy handler method for the forwarded methods.  It will never be called
+   * since those calls are intercepted in HandleMethodCall anyway.  We just
+   * need something to pass for bindAndAddMethod.
+   */
+  void
+  neverCalled (const Json::Value& params, Json::Value& result)
+  {
+    LOG (FATAL) << "method call not intercepted";
+  }
+
+public:
+
+  explicit LocalServer (jsonrpc::AbstractServerConnector& conn,
+                        charon::Client& c)
+    : jsonrpc::AbstractServer<LocalServer>(conn, jsonrpc::JSONRPC_SERVER_V2),
+      client(c)
+  {
+    jsonrpc::Procedure stopProc("stop", jsonrpc::PARAMS_BY_POSITION, nullptr);
+    bindAndAddNotification (stopProc, &LocalServer::stop);
+  }
+
+  ~LocalServer ()
+  {
+    StopListening ();
+  }
+
+  LocalServer () = delete;
+  LocalServer (const LocalServer&) = delete;
+  void operator= (const LocalServer&) = delete;
+
+  /**
+   * Adds a method with the given name (and any parameters) to the list of
+   * methods that will be forwarded.
+   */
+  void
+  AddMethod (const std::string& method)
+  {
+    jsonrpc::Procedure proc(method, jsonrpc::PARAMS_BY_POSITION,
+                            jsonrpc::JSON_OBJECT, nullptr);
+    bindAndAddMethod (proc, &LocalServer::neverCalled);
+  }
+
+  /**
+   * Listens on the server until the stop notification is sent.
+   */
+  void
+  Run ()
+  {
+    shouldStop = false;
+    StartListening ();
+
+    {
+      std::unique_lock<std::mutex> lock(mut);
+      while (!shouldStop)
+        cv.wait (lock);
+    }
+
+    StopListening ();
+  }
+
+  void
+  HandleMethodCall (jsonrpc::Procedure& proc, const Json::Value& params,
+                    Json::Value& result) override
+  {
+    result = client.ForwardMethod (proc.GetProcedureName (), params);
+  }
+
+};
+
+} // anonymous namespace
+
+int
+main (int argc, char** argv)
+{
+  google::InitGoogleLogging (argv[0]);
+
+  gflags::SetUsageMessage ("Run a Charon client");
+  gflags::SetVersionString (PACKAGE_VERSION);
+  gflags::ParseCommandLineFlags (&argc, &argv, true);
+
+  if (FLAGS_server_jid.empty ())
+    {
+      std::cerr << "Error: --server_jid must be set" << std::endl;
+      return EXIT_FAILURE;
+    }
+  if (FLAGS_client_jid.empty ())
+    {
+      std::cerr << "Error: --client_jid must be set" << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  if (FLAGS_port == 0)
+    {
+      std::cerr << "Error: --port must be set" << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  LOG (INFO) << "Using " << FLAGS_server_jid << " as server";
+  charon::Client client(FLAGS_server_jid);
+
+  LOG (INFO) << "Connecting client to XMPP as " << FLAGS_client_jid;
+  client.Connect (FLAGS_client_jid, FLAGS_password, -1);
+
+  if (FLAGS_detect_server)
+    {
+      const std::string srvResource = client.GetServerResource ();
+      if (srvResource.empty ())
+        {
+          std::cerr << "Could not detect server";
+          return EXIT_FAILURE;
+        }
+      LOG (INFO) << "Using server resource: " << srvResource;
+    }
+  else
+    LOG (WARNING) << "Not detecting server for now";
+
+  LOG (INFO) << "Listening for local RPCs on port " << FLAGS_port;
+  jsonrpc::HttpServer httpServer(FLAGS_port);
+  httpServer.BindLocalhost ();
+
+  LocalServer rpcServer(httpServer, client);
+
+  const auto methods = charon::GetSelectedMethods ();
+  if (methods.empty ())
+    LOG (WARNING) << "No methods are selected for forwarding";
+  for (const auto& m : methods)
+    {
+      LOG (INFO) << "Forwarding method: " << m;
+      rpcServer.AddMethod (m);
+    }
+
+  LOG (INFO) << "Starting RPC server...";
+  rpcServer.Run ();
+
+  return EXIT_SUCCESS;
+}

--- a/util/methods.cpp
+++ b/util/methods.cpp
@@ -1,0 +1,54 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "methods.hpp"
+
+#include <gflags/gflags.h>
+
+#include <iostream>
+#include <sstream>
+
+namespace charon
+{
+
+namespace
+{
+
+DEFINE_string (methods, "", "Comma-separated list of supported RPC methods");
+
+} // anonymous namespace
+
+std::set<std::string>
+GetSelectedMethods ()
+{
+  if (FLAGS_methods.empty ())
+    return {};
+
+  std::set<std::string> res;
+  std::istringstream methodsIn(FLAGS_methods);
+  while (methodsIn.good ())
+    {
+      std::string method;
+      std::getline (methodsIn, method, ',');
+      res.insert (method);
+    }
+
+  return res;
+}
+
+} // namespace charon

--- a/util/methods.hpp
+++ b/util/methods.hpp
@@ -1,0 +1,35 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef CHARON_UTILS_METHODS_HPP
+#define CHARON_UTILS_METHODS_HPP
+
+#include <set>
+#include <string>
+
+namespace charon
+{
+
+/**
+ * Returns the set of methods selected by --methods.
+ */
+std::set<std::string> GetSelectedMethods ();
+
+} // namespace charon
+
+#endif // CHARON_UTILS_METHODS_HPP

--- a/util/server.cpp
+++ b/util/server.cpp
@@ -1,0 +1,91 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#include "rpcserver.hpp"
+#include "server.hpp"
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <thread>
+
+namespace
+{
+
+DEFINE_string (backend_rpc_url, "",
+               "URL at which the backend JSON-RPC interface is available");
+DEFINE_string (methods, "", "Comma-separated list of methods to forward");
+
+DEFINE_string (server_jid, "", "Bare or full JID for the server");
+DEFINE_string (password, "", "XMPP password for the server JID");
+DEFINE_int32 (priority, 0, "Priority for the XMPP connection");
+
+} // anonymous namespace
+
+int
+main (int argc, char** argv)
+{
+  google::InitGoogleLogging (argv[0]);
+
+  gflags::SetUsageMessage ("Run a Charon server");
+  gflags::SetVersionString (PACKAGE_VERSION);
+  gflags::ParseCommandLineFlags (&argc, &argv, true);
+
+  if (FLAGS_backend_rpc_url.empty ())
+    {
+      std::cerr << "Error: --backend_rpc_url must be set" << std::endl;
+      return EXIT_FAILURE;
+    }
+  if (FLAGS_server_jid.empty ())
+    {
+      std::cerr << "Error: --server_jid must be set" << std::endl;
+      return EXIT_FAILURE;
+    }
+  if (FLAGS_methods.empty ())
+    {
+      std::cerr << "Error: no allowed --methods are set" << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  charon::ForwardingRpcServer backend(FLAGS_backend_rpc_url);
+  LOG (INFO)
+      << "Forwarding calls to JSON-RPC server at " << FLAGS_backend_rpc_url;
+  std::istringstream methodsIn(FLAGS_methods);
+  while (methodsIn.good ())
+    {
+      std::string method;
+      std::getline (methodsIn, method, ',');
+      LOG (INFO) << "Allowing method: " << method;
+      backend.AllowMethod (method);
+    }
+
+  LOG (INFO) << "Connecting server to XMPP as " << FLAGS_server_jid;
+  charon::Server srv(backend);
+  srv.Connect (FLAGS_server_jid, FLAGS_password, FLAGS_priority);
+
+  while (true)
+    std::this_thread::sleep_for (std::chrono::seconds (1));
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This adds two simple binaries, `charon-client` and `charon-server`.  They allow running a client/server directly from the command line, without the need to use libcharon from an external binary.

With them, we also implement an integration testing framework in Python (similar to xayagametest for GSPs) and test basic method forwarding with it.