### PR TITLE
Use directed presence in initial handshake

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -23,22 +23,31 @@ slightly out-of-sync when they process a new block.
 For this, the client initially sends an ordinary message stanza (not IQ)
 to the GSPs bare JID `gsp@server`, asking for a reply from a suitable instance:
 
-    <message>
+    <message to="gsp@server">
       <ping xmlns="https://xaya.io/charon/" />
     </message>
 
 This will then be relayed by the XMPP server to one or more available GSP
 connections (taking their priorities also into account).  A GSP client that
 receives such a message and feels ready to accept another client (i.e. is not
-overloaded) will reply with an acknowledgement:
+overloaded) will reply with a directed presence as acknowledgement:
 
-    <message>
+    <presence to="player@server/resource">
       <pong xmlns="https://xaya.io/charon/" />
-    </message>
+    </presence>
 
 The client can then select one of the replies it gets (in case there are
 multiple) and record the GSP client's full JID (including its resource)
-for further requests.
+for further requests.  Once a server is selected, the client will send
+a directed presence as well:
+
+    <presence to="gsp@server/resource" />
+
+By exchanging a pair of directed presence stanzas, the client and server
+will temporarily subscribe to each other's presence, so that they will also
+be notified about one becoming unavailable.
+(And then e.g. the client can perform another handshake to find a different
+server resource.)
 
 ## Ordinary RPC Calls
 

--- a/src/private/stanzas.hpp
+++ b/src/private/stanzas.hpp
@@ -236,7 +236,7 @@ public:
 };
 
 /**
- * A gloox StanzaExtension representing a "pong" message:
+ * A gloox StanzaExtension representing a "pong" message/presence:
  *
  *  <pong xmlns="https://xaya.io/charon/" />
  */

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -25,6 +25,7 @@
 #include <gloox/iqhandler.h>
 #include <gloox/message.h>
 #include <gloox/messagehandler.h>
+#include <gloox/presence.h>
 
 #include <glog/logging.h>
 
@@ -85,7 +86,7 @@ Server::IqAnsweringClient::handleMessage (const gloox::Message& msg,
     {
       LOG (INFO) << "Processing ping from " << msg.from ().full ();
 
-      gloox::Message response(gloox::Message::Normal, msg.from ());
+      gloox::Presence response(gloox::Presence::Available, msg.from ());
       response.addExtension (new PongMessage ());
 
       RunWithClient ([&response] (gloox::Client& c)

--- a/src/stanzas.cpp
+++ b/src/stanzas.cpp
@@ -131,7 +131,7 @@ RpcRequest::RpcRequest (const gloox::Tag& t)
 const std::string&
 RpcRequest::filterString () const
 {
-  static const std::string filter = "/iq/request[@xmlns='" XMLNS "']";
+  static const std::string filter = "/*/request[@xmlns='" XMLNS "']";
   return filter;
 }
 
@@ -282,7 +282,7 @@ RpcResponse::GetErrorData () const
 const std::string&
 RpcResponse::filterString () const
 {
-  static const std::string filter = "/iq/response[@xmlns='" XMLNS "']";
+  static const std::string filter = "/*/response[@xmlns='" XMLNS "']";
   return filter;
 }
 
@@ -359,7 +359,7 @@ PingMessage::PingMessage ()
 const std::string&
 PingMessage::filterString () const
 {
-  static const std::string filter = "/message/ping[@xmlns='" XMLNS "']";
+  static const std::string filter = "/*/ping[@xmlns='" XMLNS "']";
   return filter;
 }
 
@@ -393,7 +393,7 @@ PongMessage::PongMessage ()
 const std::string&
 PongMessage::filterString () const
 {
-  static const std::string filter = "/message/pong[@xmlns='" XMLNS "']";
+  static const std::string filter = "/*/pong[@xmlns='" XMLNS "']";
   return filter;
 }
 


### PR DESCRIPTION
This extends the protocol for the initial handshake (selection of a server resource) to use directed presence.  In particular, the "pong" message is replaced by a directed presence from server to client, and then the client also sends a directed presence back to the server.

By exchanging directed presence, both XMPP clients will temporarily subscribe to each other, and thus be notified if the other becomes unavailable.  This allows us to simplify server reselection in the client, by simply reacting to an unavailable presence for the server.