### PR TITLE
Relay update notifications through Charon

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,6 +19,7 @@ libcharon_la_SOURCES = \
   notifications.cpp \
   pubsub.cpp \
   rpcserver.cpp \
+  rpcwaiter.cpp \
   server.cpp \
   stanzas.cpp \
   waiterthread.cpp \
@@ -27,6 +28,7 @@ charon_HEADERS = \
   client.hpp \
   notifications.hpp \
   rpcserver.hpp \
+  rpcwaiter.hpp \
   server.hpp \
   waiterthread.hpp
 noinst_HEADERS = \
@@ -50,6 +52,7 @@ tests_SOURCES = \
   client_tests.cpp \
   pubsub_tests.cpp \
   rpcserver_tests.cpp \
+  rpcwaiter_tests.cpp \
   server_tests.cpp \
   stanzas_tests.cpp \
   waiterthread_tests.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,7 @@ libcharon_la_LIBADD = \
   $(GLOG_LIBS) $(GLOOX_LIBS)
 libcharon_la_SOURCES = \
   client.cpp \
+  pubsub.cpp \
   rpcserver.cpp \
   server.cpp \
   stanzas.cpp \
@@ -25,6 +26,7 @@ charon_HEADERS = \
   rpcserver.hpp \
   server.hpp
 noinst_HEADERS = \
+  private/pubsub.hpp \
   private/stanzas.hpp \
   private/xmppclient.hpp
 
@@ -42,6 +44,7 @@ tests_SOURCES = \
   testutils.cpp \
   \
   client_tests.cpp \
+  pubsub_tests.cpp \
   rpcserver_tests.cpp \
   server_tests.cpp \
   stanzas_tests.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,12 +21,14 @@ libcharon_la_SOURCES = \
   rpcserver.cpp \
   server.cpp \
   stanzas.cpp \
+  waiterthread.cpp \
   xmppclient.cpp
 charon_HEADERS = \
   client.hpp \
   notifications.hpp \
   rpcserver.hpp \
-  server.hpp
+  server.hpp \
+  waiterthread.hpp
 noinst_HEADERS = \
   private/pubsub.hpp \
   private/stanzas.hpp \
@@ -50,6 +52,7 @@ tests_SOURCES = \
   rpcserver_tests.cpp \
   server_tests.cpp \
   stanzas_tests.cpp \
+  waiterthread_tests.cpp \
   xmppclient_tests.cpp
 check_HEADERS = \
   testutils.hpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,7 @@ libcharon_la_LIBADD = \
   $(GLOG_LIBS) $(GLOOX_LIBS)
 libcharon_la_SOURCES = \
   client.cpp \
+  notifications.cpp \
   pubsub.cpp \
   rpcserver.cpp \
   server.cpp \
@@ -23,6 +24,7 @@ libcharon_la_SOURCES = \
   xmppclient.cpp
 charon_HEADERS = \
   client.hpp \
+  notifications.hpp \
   rpcserver.hpp \
   server.hpp
 noinst_HEADERS = \

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -338,7 +338,7 @@ NotificationState::WaitForChange (const Json::Value& known)
 {
   std::unique_lock<std::mutex> lock(mut);
 
-  if (hasState)
+  if (hasState && known != notification.AlwaysBlockId ())
     {
       const auto stateId = notification.ExtractStateId (state);
       if (known != stateId)

--- a/src/client_tests.cpp
+++ b/src/client_tests.cpp
@@ -1,6 +1,6 @@
 /*
     Charon - a transport system for GSP data
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -32,6 +32,7 @@
 
 #include <glog/logging.h>
 
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <thread>
@@ -229,9 +230,9 @@ public:
 };
 
 /**
- * Tests basic forwarding of RPC method calls with a Charon client.
+ * Test fixture that has a real Charon client and server.
  */
-class ClientRpcForwardingTests : public testing::Test
+class ClientTestWithServer : public testing::Test
 {
 
 private:
@@ -245,8 +246,15 @@ protected:
 
   Client client;
 
-  ClientRpcForwardingTests ()
+  ClientTestWithServer ()
     : client(JIDWithoutResource (accServer).bare ())
+  {}
+
+  /**
+   * Connects the client.
+   */
+  void
+  ConnectClient ()
   {
     client.Connect (JIDWithoutResource (accClient).full (),
                     accClient.password, 0);
@@ -256,12 +264,27 @@ protected:
    * Sets up a server connection.
    */
   std::unique_ptr<Server>
-  ConnectServer ()
+  ConnectServer (const std::string& ressource="")
   {
     auto res = std::make_unique<Server> (backend);
-    res->Connect (JIDWithoutResource (accServer).bare (),
+    res->Connect (JIDWithResource (accServer, ressource).full (),
                   accServer.password, 0);
     return res;
+  }
+
+};
+
+/**
+ * Tests basic forwarding of RPC method calls with a Charon client.
+ */
+class ClientRpcForwardingTests : public ClientTestWithServer
+{
+
+protected:
+
+  ClientRpcForwardingTests ()
+  {
+    ConnectClient ();
   }
 
 };
@@ -346,6 +369,281 @@ TEST_F (ClientRpcForwardingTests, ServerReselectionNotAvailable)
   client.SetTimeout (std::chrono::milliseconds (100));
   EXPECT_THROW (client.ForwardMethod ("echo", ParseJson (R"(["foo"])")),
                 RpcServer::Error);
+}
+
+/* ************************************************************************** */
+
+/**
+ * Asynchronous call to WaitForChange in a test.  This is essentially a future
+ * whose result we can expect as needed.
+ */
+class WaitForChangeCall
+{
+
+private:
+
+  /** The thread doing the actual call.  */
+  std::unique_ptr<std::thread> caller;
+
+  /** Set to true when the thread is done.  */
+  std::atomic<bool> done;
+
+  /** The call's result (if any).  */
+  Json::Value res;
+
+public:
+
+  /**
+   * Constructs a new instance, which will call WaitForChange on the given
+   * client with the given arguments.
+   */
+  explicit WaitForChangeCall (Client& c, const std::string& type,
+                              const Json::Value& known)
+  {
+    done = false;
+    caller = std::make_unique<std::thread> ([=, &c] ()
+      {
+        res = c.WaitForChange (type, known);
+        done = true;
+      });
+  }
+
+  WaitForChangeCall () = delete;
+  WaitForChangeCall (const WaitForChangeCall&) = delete;
+  void operator= (const WaitForChangeCall&) = delete;
+
+  /**
+   * Before the object is destroyed, the result must be awaited / expected.
+   */
+  ~WaitForChangeCall ()
+  {
+    CHECK (caller == nullptr) << "Call result not awaited";
+  }
+
+  /**
+   * Expects that the call is not yet done.
+   */
+  void
+  ExpectRunning ()
+  {
+    std::this_thread::sleep_for (std::chrono::milliseconds (100));
+    ASSERT_FALSE (done);
+  }
+
+  /**
+   * Waits for the result to be in and asserts that it matches the expected
+   * JSON value.
+   */
+  void
+  Expect (const Json::Value& expected)
+  {
+    caller->join ();
+    caller.reset ();
+
+    ASSERT_EQ (res, expected);
+  }
+
+  /**
+   * Waits for the result to be in and asserts that it matches the expected
+   * id and value.
+   */
+  void
+  Expect (const std::string& id, const std::string& value)
+  {
+    Expect (UpdatableState::GetStateJson (id, value));
+  }
+
+};
+
+/**
+ * Tests notification updates in the client.
+ */
+class ClientNotificationTests : public ClientTestWithServer
+{
+
+protected:
+
+  /**
+   * Connects the client and enables notifications with the given types
+   * before doing so.
+   */
+  void
+  ConnectClient (const std::vector<std::string>& types)
+  {
+    for (const auto& t : types)
+      client.AddNotification (
+          std::make_unique<UpdatableState::Notification> (t));
+    ClientTestWithServer::ConnectClient ();
+  }
+
+  /**
+   * Calls WaitForChange on the client and returns the call handle.
+   */
+  std::unique_ptr<WaitForChangeCall>
+  CallWaitForChange (const std::string& type, const Json::Value& known)
+  {
+    return std::make_unique<WaitForChangeCall> (client, type, known);
+  }
+
+};
+
+TEST_F (ClientNotificationTests, SelectsServerWithNotifications)
+{
+  ConnectClient ({"foo", "bar"});
+  client.SetTimeout (std::chrono::milliseconds (100));
+
+  auto s1 = ConnectServer ("nothing");
+  auto s2 = ConnectServer ("service only");
+  s2->AddPubSub (PUBSUB_SERVICE);
+  auto s3 = ConnectServer ("partial notifications");
+  s3->AddPubSub (PUBSUB_SERVICE);
+
+  UpdatableState upd;
+  s3->AddNotification (upd.NewWaiter ("foo"));
+  s3->AddNotification (upd.NewWaiter ("baz"));
+
+  std::this_thread::sleep_for (std::chrono::milliseconds (100));
+  EXPECT_EQ (client.GetServerResource (), "");
+
+  auto s4 = ConnectServer ("good");
+  s4->AddPubSub (PUBSUB_SERVICE);
+  s4->AddNotification (upd.NewWaiter ("foo"));
+  s4->AddNotification (upd.NewWaiter ("bar"));
+
+  std::this_thread::sleep_for (std::chrono::milliseconds (100));
+  EXPECT_EQ (client.GetServerResource (), "good");
+
+  /* Disconnect servers before the UpdatableState goes out of scope.  */
+  s1.reset ();
+  s2.reset ();
+  s3.reset ();
+  s4.reset ();
+}
+
+TEST_F (ClientNotificationTests, WaitForChange)
+{
+  ConnectClient ({"foo"});
+
+  auto s = ConnectServer ();
+  s->AddPubSub (PUBSUB_SERVICE);
+
+  UpdatableState upd;
+  s->AddNotification (upd.NewWaiter ("foo"));
+
+  /* Force subscriptions to be finalised by now.  */
+  client.GetServerResource ();
+
+  auto w = CallWaitForChange ("foo", "");
+  w->ExpectRunning ();
+
+  upd.SetState ("a", "first");
+  w->Expect ("a", "first");
+
+  w = CallWaitForChange ("foo", "x");
+  w->Expect ("a", "first");
+
+  w = CallWaitForChange ("foo", "a");
+  w->ExpectRunning ();
+
+  upd.SetState ("b", "second");
+  w->Expect ("b", "second");
+
+  s.reset ();
+}
+
+TEST_F (ClientNotificationTests, TwoNotifications)
+{
+  ConnectClient ({"foo", "bar"});
+
+  auto s = ConnectServer ();
+  s->AddPubSub (PUBSUB_SERVICE);
+
+  UpdatableState upd1;
+  s->AddNotification (upd1.NewWaiter ("foo"));
+  UpdatableState upd2;
+  s->AddNotification (upd2.NewWaiter ("bar"));
+
+  client.GetServerResource ();
+
+  auto w1 = CallWaitForChange ("foo", "");
+  auto w2 = CallWaitForChange ("bar", "");
+
+  w1->ExpectRunning ();
+  upd1.SetState ("a", "first");
+  w1->Expect ("a", "first");
+
+  w2->ExpectRunning ();
+  upd2.SetState ("a", "second");
+  w2->Expect ("a", "second");
+
+  s.reset ();
+}
+
+TEST_F (ClientNotificationTests, TwoServers)
+{
+  ConnectClient ({"foo"});
+
+  auto s1 = ConnectServer ("srv1");
+  s1->AddPubSub (PUBSUB_SERVICE);
+  UpdatableState upd1;
+  s1->AddNotification (upd1.NewWaiter ("foo"));
+
+  ASSERT_EQ (client.GetServerResource (), "srv1");
+
+  auto s2 = ConnectServer ("srv2");
+  s2->AddPubSub (PUBSUB_SERVICE);
+  UpdatableState upd2;
+  s2->AddNotification (upd1.NewWaiter ("foo"));
+
+  auto w = CallWaitForChange ("foo", "always block");
+  upd2.SetState ("a", "wrong");
+  w->ExpectRunning ();
+  upd1.SetState ("a", "correct");
+  w->Expect ("a", "correct");
+
+  s1.reset ();
+  s2.reset ();
+}
+
+TEST_F (ClientNotificationTests, ServerReselection)
+{
+  ConnectClient ({"foo"});
+
+  UpdatableState upd;
+
+  auto s = ConnectServer ("srv1");
+  s->AddPubSub (PUBSUB_SERVICE);
+  s->AddNotification (upd.NewWaiter ("foo"));
+
+  EXPECT_EQ (client.GetServerResource (), "srv1");
+  auto w = CallWaitForChange ("foo", "");
+
+  s = ConnectServer ("srv2");
+  s->AddPubSub (PUBSUB_SERVICE);
+  s->AddNotification (upd.NewWaiter ("foo"));
+
+  /* Note that reselection only happens when an explicit action triggers it.
+     We do this by selecting (and checking) the server resource again.  */
+  EXPECT_EQ (client.GetServerResource (), "srv2");
+
+  w->ExpectRunning ();
+  upd.SetState ("a", "value");
+  w->Expect ("a", "value");
+
+  /* Try again.  This time we trigger reselection through the call itself,
+     and only use GetServerResource to force all subscriptions to be done
+     before updating the server state.  */
+  s = ConnectServer ("srv3");
+  s->AddPubSub (PUBSUB_SERVICE);
+  s->AddNotification (upd.NewWaiter ("foo"));
+
+  w = CallWaitForChange ("foo", "always block");
+  EXPECT_EQ (client.GetServerResource (), "srv3");
+  w->ExpectRunning ();
+  upd.SetState ("b", "value 2");
+  w->Expect ("b", "value 2");
+
+  s.reset ();
 }
 
 /* ************************************************************************** */

--- a/src/notifications.cpp
+++ b/src/notifications.cpp
@@ -1,0 +1,44 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "notifications.hpp"
+
+#include <glog/logging.h>
+
+namespace charon
+{
+
+Json::Value
+StateChangeNotification::ExtractStateId (const Json::Value& fullState) const
+{
+  CHECK (fullState.isString ());
+  return fullState;
+}
+
+Json::Value
+PendingChangeNotification::ExtractStateId (const Json::Value& fullState) const
+{
+  CHECK (fullState.isObject ());
+
+  const auto& version = fullState["version"];
+  CHECK (version.isUInt ());
+
+  return version;
+}
+
+} // namespace charon

--- a/src/notifications.cpp
+++ b/src/notifications.cpp
@@ -31,6 +31,12 @@ StateChangeNotification::ExtractStateId (const Json::Value& fullState) const
 }
 
 Json::Value
+StateChangeNotification::AlwaysBlockId () const
+{
+  return "";
+}
+
+Json::Value
 PendingChangeNotification::ExtractStateId (const Json::Value& fullState) const
 {
   CHECK (fullState.isObject ());
@@ -39,6 +45,12 @@ PendingChangeNotification::ExtractStateId (const Json::Value& fullState) const
   CHECK (version.isUInt ());
 
   return version;
+}
+
+Json::Value
+PendingChangeNotification::AlwaysBlockId () const
+{
+  return 0;
 }
 
 } // namespace charon

--- a/src/notifications.hpp
+++ b/src/notifications.hpp
@@ -1,0 +1,122 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef CHARON_NOTIFICATIONS_HPP
+#define CHARON_NOTIFICATIONS_HPP
+
+#include <json/json.h>
+
+#include <string>
+
+namespace charon
+{
+
+/**
+ * Interface that defines the specifics of a particular notification type
+ * that we can support.  This handles the interface of the notification,
+ * i.e. what JSON data it contains, how states are "identified" (e.g. the
+ * associated block hash or a pending version ID), and how a client can
+ * retrieve the initial state from a Charon server on startup.
+ *
+ * This does not specify the particular way in which a Charon server will
+ * talk to its GSP backend for getting updates itself, because that is an
+ * orthogonal issue and may depend on the concrete GSP structure.
+ */
+class NotificationType
+{
+
+private:
+
+  /** The type of this notification as string.  */
+  const std::string type;
+
+protected:
+
+  /**
+   * Constructs the instance.  Subclasses must define the type string.
+   */
+  explicit NotificationType (const std::string& t)
+    : type(t)
+  {}
+
+public:
+
+  NotificationType () = delete;
+  NotificationType (const NotificationType&) = delete;
+  void operator= (const NotificationType&) = delete;
+
+  virtual ~NotificationType () = default;
+
+  /**
+   * Returns the type string.
+   */
+  const std::string&
+  GetType () const
+  {
+    return type;
+  }
+
+  /**
+   * Subclasses must implement this method to return the parameter value
+   * for "current state" that uniquely identifies its "version".  This value
+   * must be usable to compare for equality with a known state, and is also
+   * what gets passed as "known version" argument to the waiter method.
+   *
+   * The method should just be a pure function of its input.
+   */
+  virtual Json::Value ExtractStateId (const Json::Value& fullState) const = 0;
+
+};
+
+/**
+ * NotificationType implementation for the game-state update with new blocks,
+ * i.e. matching the waitforchange RPC method.
+ */
+class StateChangeNotification : public NotificationType
+{
+
+public:
+
+  StateChangeNotification ()
+    : NotificationType ("state")
+  {}
+
+  Json::Value ExtractStateId (const Json::Value& fullState) const override;
+
+};
+
+/**
+ * NotificationType implementation for the pending-move update, matching
+ * the waitforpendingchange polling RPC.
+ */
+class PendingChangeNotification : public NotificationType
+{
+
+public:
+
+  PendingChangeNotification ()
+    : NotificationType ("pending")
+  {}
+
+  Json::Value ExtractStateId (const Json::Value& fullState) const override;
+
+};
+
+} // namespace charon
+
+#endif // CHARON_NOTIFICATIONS_HPP

--- a/src/notifications.hpp
+++ b/src/notifications.hpp
@@ -81,6 +81,12 @@ public:
    */
   virtual Json::Value ExtractStateId (const Json::Value& fullState) const = 0;
 
+  /**
+   * Should return the state ID value that indicates that WaitForChange should
+   * always block (i.e. that there is no currently known state).
+   */
+  virtual Json::Value AlwaysBlockId () const = 0;
+
 };
 
 /**
@@ -97,6 +103,7 @@ public:
   {}
 
   Json::Value ExtractStateId (const Json::Value& fullState) const override;
+  Json::Value AlwaysBlockId () const override;
 
 };
 
@@ -114,6 +121,7 @@ public:
   {}
 
   Json::Value ExtractStateId (const Json::Value& fullState) const override;
+  Json::Value AlwaysBlockId () const override;
 
 };
 

--- a/src/private/pubsub.hpp
+++ b/src/private/pubsub.hpp
@@ -1,0 +1,123 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef CHARON_PUBSUB_HPP
+#define CHARON_PUBSUB_HPP
+
+#include <gloox/jid.h>
+#include <gloox/message.h>
+#include <gloox/messagehandler.h>
+#include <gloox/pubsubmanager.h>
+#include <gloox/tag.h>
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+
+namespace charon
+{
+
+class XmppClient;
+
+/**
+ * Implementation of the core XMPP pubsub logic that we need for implementing
+ * state and pending notifications for Charon.  This is mostly a wrapper around
+ * gloox' pubsub logic, exposing the simplified subset that we need in a
+ * convenient form.
+ *
+ * This class is meant to be used through XmppClient and not instantiated
+ * directly by itself.
+ */
+class PubSubImpl : private gloox::MessageHandler
+{
+
+public:
+
+  /** Callback type for received published items.  */
+  using ItemCallback = std::function<void (const gloox::Tag& t)>;
+
+private:
+
+  /** The underlying XmppClient.  */
+  XmppClient& client;
+
+  /** The gloox PubSub::Manager we use.  */
+  gloox::PubSub::Manager manager;
+
+  /** JID of the pubsub service.  */
+  const gloox::JID service;
+
+  /** Nodes owned by this pubsub instance.  */
+  std::set<std::string> ownedNodes;
+
+  /** Nodes subscribed to and the corresponding callbacks for items.  */
+  std::map<std::string, ItemCallback> subscriptions;
+
+  void handleMessage (const gloox::Message& msg,
+                      gloox::MessageSession* session) override;
+
+public:
+
+  /**
+   * Constructs the PubSub manager based on a given XmppClient instance.
+   */
+  explicit PubSubImpl (XmppClient& cl, const gloox::JID& s);
+
+  /**
+   * Sends requests to unsubscribe from all nodes we are subscribed to and to
+   * delete all nodes that we own (without waiting for the results to arrive).
+   */
+  ~PubSubImpl ();
+
+  PubSubImpl () = delete;
+  PubSubImpl (const PubSubImpl&) = delete;
+  void operator= (const PubSubImpl&) = delete;
+
+  /**
+   * Returns the pubsub service this is using.
+   */
+  const gloox::JID&
+  GetService () const
+  {
+    return service;
+  }
+
+  /**
+   * Creates a new instant node and returns its ID once done.
+   * CHECK fails if node creation errors.
+   */
+  std::string CreateNode ();
+
+  /**
+   * Publishes a given tag to the given node.  It must be a node we own
+   * (i.e. created before).
+   */
+  void Publish (const std::string& node, std::unique_ptr<gloox::Tag> data);
+
+  /**
+   * Subscribes to the given node.  Returns true on success, false on error.
+   */
+  bool SubscribeToNode (const std::string& node, const ItemCallback& cb);
+
+};
+
+} // namespace charon
+
+#endif // CHARON_PUBSUB_HPP

--- a/src/private/xmppclient.hpp
+++ b/src/private/xmppclient.hpp
@@ -32,6 +32,8 @@
 namespace charon
 {
 
+class PubSubImpl;
+
 /**
  * Basic XMPP client, based on the gloox library.  It manages the connection
  * and logs, but does not have any specific listening or other logic by itself.
@@ -50,6 +52,9 @@ private:
 
   /** The gloox XMPP client instance.  */
   gloox::Client client;
+
+  /** PubSub instance used by this client.  */
+  std::unique_ptr<PubSubImpl> pubsub;
 
   /**
    * When connected, this is the thread running polling for new messages.
@@ -83,6 +88,8 @@ private:
   void handleLog (gloox::LogLevel level, gloox::LogArea area,
                   const std::string& msg) override;
 
+  friend class PubSubImpl;
+
 public:
 
   /**
@@ -99,6 +106,17 @@ public:
   XmppClient () = delete;
   XmppClient (const XmppClient&) = delete;
   void operator= (const XmppClient&) = delete;
+
+  /**
+   * Adds a pubsub handler for the given pubsub service JID.
+   */
+  void AddPubSub (const gloox::JID& service);
+
+  /**
+   * Gives access to the pubsub instance.  Must only be called if one was
+   * initialised with AddPubSub already.
+   */
+  PubSubImpl& GetPubSub ();
 
   /**
    * Sets up the connection to the server, using the specified priority.

--- a/src/pubsub.cpp
+++ b/src/pubsub.cpp
@@ -1,0 +1,438 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "private/pubsub.hpp"
+
+#include "private/xmppclient.hpp"
+
+#include <gloox/clientbase.h>
+#include <gloox/pubsubevent.h>
+#include <gloox/pubsubitem.h>
+#include <gloox/pubsubresulthandler.h>
+
+#include <glog/logging.h>
+
+#include <condition_variable>
+#include <mutex>
+
+namespace charon
+{
+
+namespace
+{
+
+/**
+ * PubSub::ResultHandler instance that defines all methods but CHECK's that
+ * they are not called.  This allows for convenient subclassing where we only
+ * have to actually override the methods appropriate for what results we
+ * expect from the call.
+ */
+class GeneralResultHandler : public gloox::PubSub::ResultHandler
+{
+
+public:
+
+  GeneralResultHandler () = default;
+
+#define UNSUPPORTED_METHOD(name, args) \
+  void name args override \
+  { \
+    LOG (FATAL) << "Method " #name " is not supported"; \
+  }
+
+  UNSUPPORTED_METHOD (handleItem,
+      (const gloox::JID&, const std::string&, const gloox::Tag*));
+  UNSUPPORTED_METHOD (handleItems,
+      (const std::string&, const gloox::JID&, const std::string&,
+       const gloox::PubSub::ItemList&, const gloox::Error*));
+  UNSUPPORTED_METHOD (handleItemPublication,
+      (const std::string&, const gloox::JID&, const std::string&,
+       const gloox::PubSub::ItemList&, const gloox::Error*));
+  UNSUPPORTED_METHOD (handleItemDeletion,
+      (const std::string&, const gloox::JID&, const std::string&,
+       const gloox::PubSub::ItemList&, const gloox::Error*));
+
+  UNSUPPORTED_METHOD (handleSubscriptionResult,
+      (const std::string&, const gloox::JID&, const std::string&,
+       const std::string&, const gloox::JID&,
+       gloox::PubSub::SubscriptionType, const gloox::Error*));
+  UNSUPPORTED_METHOD (handleUnsubscriptionResult,
+      (const std::string&, const gloox::JID&, const gloox::Error*));
+  UNSUPPORTED_METHOD (handleSubscriptionOptions,
+      (const std::string&, const gloox::JID&, const gloox::JID&,
+       const std::string&, const gloox::DataForm*,
+       const std::string&, const gloox::Error*));
+  UNSUPPORTED_METHOD (handleSubscriptionOptionsResult,
+      (const std::string&, const gloox::JID&, const gloox::JID&,
+       const std::string&, const std::string&, const gloox::Error*));
+
+  UNSUPPORTED_METHOD (handleSubscribers,
+      (const std::string&, const gloox::JID&, const std::string&,
+       const gloox::PubSub::SubscriptionList&, const gloox::Error*));
+  UNSUPPORTED_METHOD (handleSubscribersResult,
+      (const std::string&, const gloox::JID&, const std::string&,
+       const gloox::PubSub::SubscriberList*, const gloox::Error*));
+  UNSUPPORTED_METHOD (handleAffiliates,
+      (const std::string&, const gloox::JID&, const std::string&,
+       const gloox::PubSub::AffiliateList*, const gloox::Error*));
+  UNSUPPORTED_METHOD (handleAffiliatesResult,
+      (const std::string&, const gloox::JID&, const std::string&,
+       const gloox::PubSub::AffiliateList*, const gloox::Error*));
+
+  UNSUPPORTED_METHOD (handleNodeConfig,
+      (const std::string&, const gloox::JID&, const std::string&,
+       const gloox::DataForm*, const gloox::Error*));
+  UNSUPPORTED_METHOD (handleNodeConfigResult,
+      (const std::string&, const gloox::JID&, const std::string&,
+       const gloox::Error*));
+
+  UNSUPPORTED_METHOD (handleNodeCreation,
+      (const std::string&, const gloox::JID&, const std::string&,
+       const gloox::Error*));
+  UNSUPPORTED_METHOD (handleNodeDeletion,
+      (const std::string&, const gloox::JID&, const std::string&,
+       const gloox::Error*));
+  UNSUPPORTED_METHOD (handleNodePurge,
+      (const std::string&, const gloox::JID&, const std::string&,
+       const gloox::Error*));
+
+  UNSUPPORTED_METHOD (handleSubscriptions,
+      (const std::string&, const gloox::JID&,
+       const gloox::PubSub::SubscriptionMap&, const gloox::Error*));
+  UNSUPPORTED_METHOD (handleAffiliations,
+      (const std::string&, const gloox::JID&,
+       const gloox::PubSub::AffiliationMap&, const gloox::Error*));
+  UNSUPPORTED_METHOD (handleDefaultNodeConfig,
+      (const std::string&, const gloox::JID&, const gloox::DataForm*,
+       const gloox::Error*));
+
+#undef UNSUPPORTED_METHOD
+
+};
+
+/**
+ * ResultHandler that accepts node deletion and unsubscription results
+ * (as we get them for cleaning up a PubSubImpl).
+ */
+class CleanUpResultHandler : public GeneralResultHandler
+{
+
+public:
+
+  void
+  handleNodeDeletion (const std::string& id, const gloox::JID& service,
+                      const std::string& node,
+                      const gloox::Error* error) override
+  {
+    if (error == nullptr)
+      VLOG (1) << "Node " << node << " has been deleted";
+    else
+      LOG (ERROR) << "Error deleting node " << node << ": " << error->text ();
+  }
+
+  void
+  handleUnsubscriptionResult (const std::string& id, const gloox::JID& service,
+                              const gloox::Error* error) override
+  {
+    if (error == nullptr)
+      VLOG (1) << "Unsubscribed from node";
+    else
+      LOG (ERROR) << "Error unsubscribing: " << error->text ();
+  }
+
+};
+
+/**
+ * ResultHandler that notifies a condition variable and sets a flag
+ * when done.
+ */
+class WaiterResultHandler : public GeneralResultHandler
+{
+
+private:
+
+  /** Mutex for the condition variable and flag.  */
+  std::mutex mut;
+
+  /** Condition variable to wait on.  */
+  std::condition_variable cv;
+
+  /** Whether or not we are done.  */
+  bool done = false;
+
+protected:
+
+  /**
+   * Signal the action as done.  This should be called from subclasses
+   * from the respective handle... method.
+   */
+  void
+  Notify ()
+  {
+    std::lock_guard<std::mutex> lock(mut);
+    done = true;
+    cv.notify_all ();
+  }
+
+public:
+
+  /**
+   * Wait for the result to be done.
+   */
+  void
+  Wait ()
+  {
+    std::unique_lock<std::mutex> lock(mut);
+    while (!done)
+      cv.wait (lock);
+  }
+
+};
+
+/**
+ * ResultHandler that waits for a node creation confirmation.
+ */
+class NodeCreationResultHandler : public WaiterResultHandler
+{
+
+private:
+
+  /** The created node's name.  */
+  std::string node;
+
+public:
+
+  void
+  handleNodeCreation (const std::string& id, const gloox::JID& service,
+                      const std::string& n, const gloox::Error* error) override
+  {
+    CHECK (error == nullptr) << "Error creating node: " << error->text ();
+    VLOG (1) << "Successfully created node " << n;
+    node = n;
+    Notify ();
+  }
+
+  const std::string&
+  GetNode () const
+  {
+    CHECK (!node.empty ());
+    return node;
+  }
+
+};
+
+/**
+ * ResultHandler that waits for an item publication confirmation.
+ */
+class ItemPublicationResultHandler : public WaiterResultHandler
+{
+
+public:
+
+  void
+  handleItemPublication (const std::string& id, const gloox::JID& service,
+                         const std::string& node,
+                         const gloox::PubSub::ItemList& items,
+                         const gloox::Error* error) override
+  {
+    CHECK (error == nullptr)
+        << "Error publishing to " << node << ": " << error->text ();
+    VLOG (1) << "Successfully published to " << node;
+    Notify ();
+  }
+
+};
+
+/**
+ * ResultHandler that waits for a node subscription confirmation.
+ */
+class NodeSubscriptionResultHandler : public WaiterResultHandler
+{
+
+private:
+
+  /** Whether or not subscription was successful.  */
+  bool success;
+
+public:
+
+  void
+  handleSubscriptionResult (const std::string& id, const gloox::JID& service,
+                            const std::string& node, const std::string& sid,
+                            const gloox::JID& jid,
+                            const gloox::PubSub::SubscriptionType subType,
+                            const gloox::Error* error) override
+  {
+    if (error != nullptr)
+      {
+        LOG (ERROR)
+            << "Error subscribing to " << node << ": " << error->text ();
+        success = false;
+      }
+    else if (subType != gloox::PubSub::SubscriptionSubscribed)
+      {
+        LOG (ERROR)
+            << "Subscription status for node " << node << ": " << subType;
+        success = false;
+      }
+    else
+      {
+        VLOG (1) << "Successfully subscribed to " << node;
+        success = true;
+      }
+
+    Notify ();
+  }
+
+  bool
+  GetSuccess () const
+  {
+    return success;
+  }
+
+};
+
+} // anonymous namespace
+
+PubSubImpl::PubSubImpl (XmppClient& cl, const gloox::JID& s)
+  : client(cl), manager(&client.client), service(s)
+{
+  client.RunWithClient ([this] (gloox::Client& c)
+    {
+      c.registerStanzaExtension (new gloox::PubSub::Event ());
+      c.registerMessageHandler (this);
+    });
+}
+
+PubSubImpl::~PubSubImpl ()
+{
+  client.RunWithClient ([this] (gloox::Client& c)
+    {
+      c.removeMessageHandler (this);
+
+      CleanUpResultHandler handler;
+
+      LOG (INFO)
+          << "Unsubscribing from " << subscriptions.size () << " nodes...";
+      for (const auto& entry : subscriptions)
+        manager.removeID (manager.unsubscribe (service, entry.first, "",
+                                               &handler));
+
+      LOG (INFO) << "Deleting " << ownedNodes.size () << " owned nodes...";
+      for (const auto& node : ownedNodes)
+        manager.removeID (manager.deleteNode (service, node, &handler));
+    });
+}
+
+void
+PubSubImpl::handleMessage (const gloox::Message& msg,
+                           gloox::MessageSession* session)
+{
+  const auto* pse
+      = msg.findExtension<gloox::PubSub::Event> (gloox::ExtPubSubEvent);
+  if (pse == nullptr || pse->type () != gloox::PubSub::EventItems)
+    return;
+
+  LOG (INFO)
+      << "Received pubsub item for node " << pse->node ()
+      << " from " << msg.from ().full ();
+  for (const auto& itm : pse->items ())
+    {
+      if (itm->retract)
+        continue;
+
+      VLOG (1) << "Item XML:\n" << itm->payload->xml ();
+      const auto mit = subscriptions.find (pse->node ());
+      if (mit == subscriptions.end ())
+        LOG (WARNING)
+            << "Ignoring item for non-subscribed node " << pse->node ();
+      else
+        mit->second (*itm->payload);
+    }
+}
+
+std::string
+PubSubImpl::CreateNode ()
+{
+  NodeCreationResultHandler handler;
+  std::string id;
+  client.RunWithClient ([&] (gloox::Client& c)
+    {
+      id = manager.createNode (service, "", nullptr, &handler);
+    });
+  CHECK (!id.empty ());
+  handler.Wait ();
+
+  const auto& node = handler.GetNode ();
+  ownedNodes.insert (node);
+
+  /* Be extra safe and make sure that the handler is no longer tracked by
+     gloox before it goes out of scope (it should have been removed already
+     when the result was received).  */
+  CHECK (!manager.removeID (id));
+
+  return node;
+}
+
+void
+PubSubImpl::Publish (const std::string& node, std::unique_ptr<gloox::Tag> data)
+{
+  CHECK_GT (ownedNodes.count (node), 0)
+      << "Can't publish to non-owned node " << node;
+
+  auto item = std::make_unique<gloox::PubSub::Item> ();
+  item->setPayload (data.release ());
+  gloox::PubSub::ItemList items;
+  items.push_back (item.release ());
+
+  ItemPublicationResultHandler handler;
+  std::string id;
+  client.RunWithClient ([&] (gloox::Client& c)
+    {
+      id = manager.publishItem (service, node, items, nullptr, &handler);
+    });
+  CHECK (!id.empty ());
+  handler.Wait ();
+
+  CHECK (!manager.removeID (id));
+}
+
+bool
+PubSubImpl::SubscribeToNode (const std::string& node, const ItemCallback& cb)
+{
+  NodeSubscriptionResultHandler handler;
+  std::string id;
+  client.RunWithClient ([&] (gloox::Client& c)
+    {
+      id = manager.subscribe (service, node, &handler);
+    });
+
+  if (id.empty ())
+    return false;
+
+  handler.Wait ();
+  
+  const bool ok = handler.GetSuccess ();
+  if (ok)
+    subscriptions.emplace (node, cb);
+
+  CHECK (!manager.removeID (id));
+  return ok;
+}
+
+} // namespace charon

--- a/src/pubsub_tests.cpp
+++ b/src/pubsub_tests.cpp
@@ -1,0 +1,256 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2019  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "private/pubsub.hpp"
+
+#include "private/xmppclient.hpp"
+
+#include "testutils.hpp"
+
+#include <gloox/tag.h>
+
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+#include <vector>
+
+namespace charon
+{
+namespace
+{
+
+/* ************************************************************************** */
+
+/**
+ * Simple wrapper around XmppClient that automatically logs into a test account
+ * and enables pubsub.  Also incorporates a receiver for items.
+ */
+class PubSubClient : public XmppClient
+{
+
+private:
+
+  ReceivedMessages recv;
+
+public:
+
+  explicit PubSubClient (const TestAccount& acc, const std::string res = "")
+    : XmppClient(JIDWithResource (acc, res), acc.password)
+  {
+    Connect (0);
+    AddPubSub (gloox::JID (PUBSUB_SERVICE));
+  }
+
+  /**
+   * Tries to subscribe to the given node.  This uses a callback that
+   * just puts received item payloads into the queue of received messages.
+   */
+  bool
+  Subscribe (const std::string& node)
+  {
+    const auto cb = [this] (const gloox::Tag& t)
+      {
+        ASSERT_EQ (t.children ().size (), 1);
+        recv.Add ((*t.children ().begin ())->xml ());
+      };
+
+    return GetPubSub ().SubscribeToNode (node, cb);
+  }
+
+  /**
+   * Expects the given list of inner XML strings.
+   */
+  void
+  ExpectItems (const std::vector<std::string>& expected)
+  {
+    recv.Expect (expected);
+  }
+
+  /**
+   * Publishes a tag with the given name and inner text data.  Returns the
+   * tag's XML, which is what the NotificationReceiver will need.
+   */
+  std::string
+  Publish (const std::string& node, const std::string& name,
+           const std::string& text)
+  {
+    auto t = std::make_unique<gloox::Tag> (name, text);
+    const std::string res = t->xml ();
+    GetPubSub ().Publish (node, std::move (t));
+    return res;
+  }
+
+};
+
+/**
+ * Test case with two XMPP clients and pubsub between them.
+ */
+class PubSubTests : public testing::Test
+{
+
+protected:
+
+  PubSubClient client;
+  PubSubClient server;
+
+  PubSubTests ()
+    : client(ACCOUNTS[0]), server(ACCOUNTS[1])
+  {}
+
+};
+
+/* ************************************************************************** */
+
+TEST_F (PubSubTests, CreateAndSubscribe)
+{
+  const auto node = server.GetPubSub ().CreateNode ();
+  LOG (INFO) << "Created node: " << node;
+  EXPECT_TRUE (client.Subscribe (node));
+}
+
+TEST_F (PubSubTests, SubscribeToNonExistantNode)
+{
+  EXPECT_FALSE (client.Subscribe ("node does not exist"));
+}
+
+TEST_F (PubSubTests, PublishReceive)
+{
+  const auto node = server.GetPubSub ().CreateNode ();
+  ASSERT_TRUE (client.Subscribe (node));
+
+  const auto xml1 = server.Publish (node, "mytag", "with some text");
+  const auto xml2 = server.Publish (node, "othertag", "other text");
+
+  client.ExpectItems ({xml1, xml2});
+}
+
+TEST_F (PubSubTests, SubscribeAfterFirstPublish)
+{
+  const auto node = server.GetPubSub ().CreateNode ();
+  server.Publish (node, "mytag", "should not be received");
+
+  ASSERT_TRUE (client.Subscribe (node));
+  const auto xml = server.Publish (node, "othertag", "this is received");
+
+  client.ExpectItems ({xml});
+
+}
+
+TEST_F (PubSubTests, TwoClients)
+{
+  const auto node = server.GetPubSub ().CreateNode ();
+  ASSERT_TRUE (client.Subscribe (node));
+
+  PubSubClient otherClient(ACCOUNTS[0]);
+  ASSERT_TRUE (otherClient.Subscribe (node));
+
+  const auto xml1 = server.Publish (node, "tag1", "first");
+  const auto xml2 = server.Publish (node, "tag2", "second");
+
+  client.ExpectItems ({xml1, xml2});
+  otherClient.ExpectItems ({xml1, xml2});
+}
+
+TEST_F (PubSubTests, OneClientUnsubscribes)
+{
+  const auto node = server.GetPubSub ().CreateNode ();
+  ASSERT_TRUE (client.Subscribe (node));
+
+  std::string xml1;
+  {
+    PubSubClient otherClient(ACCOUNTS[0]);
+    ASSERT_TRUE (otherClient.Subscribe (node));
+
+    xml1 = server.Publish (node, "tag1", "first");
+    otherClient.ExpectItems ({xml1});
+  }
+
+  const auto xml2 = server.Publish (node, "tag2", "second");
+  client.ExpectItems ({xml1, xml2});
+}
+
+TEST_F (PubSubTests, ClientReconnectNotAutomaticallySubscribed)
+{
+  const auto node = server.GetPubSub ().CreateNode ();
+
+  {
+    PubSubClient otherClient(ACCOUNTS[0], "res");
+    ASSERT_TRUE (otherClient.Subscribe (node));
+
+    const auto xml = server.Publish (node, "tag1", "first");
+    otherClient.ExpectItems ({xml});
+  }
+
+  /* Now reconnect with the same JID, but do not immediately subscribe to
+     the node again.  Only after we explicitly subscribe should we receive
+     published items again.  */
+  {
+    PubSubClient otherClient(ACCOUNTS[0], "res");
+    server.Publish (node, "tag2", "second");
+
+    ASSERT_TRUE (otherClient.Subscribe (node));
+    const auto xml = server.Publish (node, "tag3", "third");
+
+    otherClient.ExpectItems ({xml});
+  }
+}
+
+TEST_F (PubSubTests, NodeGoesOffline)
+{
+  PubSubClient otherServer(ACCOUNTS[1]);
+  const auto node = otherServer.GetPubSub ().CreateNode ();
+  ASSERT_TRUE (client.Subscribe (node));
+  /* It is fine that the node goes offline and is deleted before the
+     client unsubscribes from it.  */
+}
+
+TEST_F (PubSubTests, ServerCleansUpNode)
+{
+  std::string node;
+  {
+    PubSubClient otherServer(ACCOUNTS[1]);
+    node = otherServer.GetPubSub ().CreateNode ();
+  }
+
+  EXPECT_FALSE (client.Subscribe (node));
+}
+
+TEST_F (PubSubTests, TwoServers)
+{
+  const auto node1 = server.GetPubSub ().CreateNode ();
+  ASSERT_TRUE (client.Subscribe (node1));
+
+  std::vector<std::string> xmls;
+  {
+    PubSubClient otherServer(ACCOUNTS[1]);
+    const auto node2 = otherServer.GetPubSub ().CreateNode ();
+    ASSERT_TRUE (client.Subscribe (node2));
+
+    xmls.push_back (server.Publish (node1, "tag1", "first"));
+    xmls.push_back (otherServer.Publish (node2, "tag2", "second"));
+  }
+
+  xmls.push_back (server.Publish (node1, "tag3", "third"));
+  client.ExpectItems (xmls);
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace charon

--- a/src/rpcwaiter.cpp
+++ b/src/rpcwaiter.cpp
@@ -1,0 +1,62 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "rpcwaiter.hpp"
+
+#include <jsonrpccpp/common/exception.h>
+
+#include <glog/logging.h>
+
+namespace charon
+{
+
+RpcUpdateWaiter::RpcUpdateWaiter (const std::string& url, const std::string& m,
+                                  const Json::Value& alwaysBlock)
+  : method(m), params(Json::arrayValue),
+    http(url), target(http)
+{
+  params.append (alwaysBlock);
+}
+
+bool
+RpcUpdateWaiter::WaitForUpdate (Json::Value& newState)
+{
+  VLOG (1) << "Calling backend waiter RPC " << method << "...";
+
+  std::unique_lock<std::mutex> lock(mut, std::try_to_lock);
+  CHECK (lock.owns_lock ()) << "Concurrent calls to WaitForUpdate";
+
+  try
+    {
+      newState = target.CallMethod (method, params);
+      return true;
+    }
+  catch (const jsonrpc::JsonRpcException& exc)
+    {
+      LOG (WARNING) << "Long-polling call returned error: " << exc.what ();
+      return false;
+    }
+}
+
+void
+RpcUpdateWaiter::ShortTimeout ()
+{
+  http.SetTimeout (50);
+}
+
+} // namespace charon

--- a/src/rpcwaiter.hpp
+++ b/src/rpcwaiter.hpp
@@ -1,0 +1,87 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef CHARON_RPCWAITER_HPP
+#define CHARON_RPCWAITER_HPP
+
+#include "waiterthread.hpp"
+
+#include <json/json.h>
+#include <jsonrpccpp/client.h>
+#include <jsonrpccpp/client/connectors/httpclient.h>
+
+#include <mutex>
+#include <string>
+
+namespace charon
+{
+
+/**
+ * Implementation of the UpdateWaiter interface that simply calls a long-polling
+ * RPC method on a given server.  Note that each instance only supports one
+ * concurrent WaitForUpdate call.
+ */
+class RpcUpdateWaiter : public UpdateWaiter
+{
+
+private:
+
+  /** The name of the method to call.  */
+  const std::string method;
+
+  /** The argument list to pass to the method.  */
+  Json::Value params;
+
+  /**
+   * Mutex used to synchronise access to our RPC client.  Note that we use
+   * this mostly to enforce that no concurrent calls are made, rather than
+   * actually allow them.
+   */
+  std::mutex mut;
+
+  /** HTTP connector for the backend target.  */
+  jsonrpc::HttpClient http;
+
+  /** The RPC client we forward calls to.  */
+  jsonrpc::Client target;
+
+  /**
+   * Sets a short timeout on the HTTP client, so that we can test what
+   * happens if a timeout occurs in unit testing.
+   */
+  void ShortTimeout ();
+
+  friend class RpcUpdateWaiterTests;
+
+public:
+
+  /**
+   * Constructs a new instance with the given RPC backend and method name.
+   * This must specify an "always block" argument that will be passed as
+   * only positional argument to each call.
+   */
+  explicit RpcUpdateWaiter (const std::string& url, const std::string& m,
+                            const Json::Value& alwaysBlock);
+
+  bool WaitForUpdate (Json::Value& newState) override;
+
+};
+
+} // namespace charon
+
+#endif // CHARON_RPCWAITER_HPP

--- a/src/rpcwaiter_tests.cpp
+++ b/src/rpcwaiter_tests.cpp
@@ -1,0 +1,165 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "rpcwaiter.hpp"
+
+#include "testutils.hpp"
+
+#include <jsonrpccpp/server.h>
+#include <jsonrpccpp/server/connectors/httpserver.h>
+
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+#include <thread>
+
+namespace charon
+{
+namespace
+{
+
+/** RPC port for our test backend server.  */
+constexpr int RPC_PORT = 42042;
+
+/** HTTP URL for the test backend server.  */
+constexpr const char* RPC_URL = "http://localhost:42042";
+
+/* ************************************************************************** */
+
+/**
+ * Implementation of the RPC backend server we use for testing.
+ */
+class TestBackendServer
+{
+
+private:
+
+  class Implementation : public jsonrpc::AbstractServer<Implementation>
+  {
+
+  public:
+
+    explicit Implementation (jsonrpc::AbstractServerConnector& conn)
+      : jsonrpc::AbstractServer<Implementation>(conn,
+                                                jsonrpc::JSONRPC_SERVER_V2)
+    {
+      const jsonrpc::Procedure proc("wait", jsonrpc::PARAMS_BY_POSITION,
+                                    jsonrpc::JSON_STRING, nullptr);
+      bindAndAddMethod (proc, &Implementation::wait);
+    }
+
+    void
+    wait (const Json::Value& params, Json::Value& res)
+    {
+      ASSERT_EQ (params, ParseJson (R"(["always block"])"));
+
+      /* The sleep here must be longer than the "short" HTTP client timeout
+         set on the RpcUpdateWaiter.  */
+      std::this_thread::sleep_for (std::chrono::milliseconds (100));
+
+      res = "new state";
+    }
+
+  };
+
+  /** The underlying HTTP server connector.  */
+  jsonrpc::HttpServer http;
+
+  /** The server implementation.  */
+  Implementation server;
+
+public:
+
+  TestBackendServer ()
+    : http(RPC_PORT), server(http)
+  {
+    server.StartListening ();
+  }
+
+  ~TestBackendServer ()
+  {
+    server.StopListening ();
+  }
+
+};
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+
+class RpcUpdateWaiterTests : public testing::Test
+{
+
+private:
+
+  TestBackendServer backend;
+
+protected:
+
+  RpcUpdateWaiter waiter;
+
+  RpcUpdateWaiterTests ()
+    : waiter(RPC_URL, "wait", "always block")
+  {}
+
+  void
+  EnableShortTimeout ()
+  {
+    waiter.ShortTimeout ();
+  }
+
+};
+
+namespace
+{
+
+TEST_F (RpcUpdateWaiterTests, CallsWork)
+{
+  Json::Value newState;
+  ASSERT_TRUE (waiter.WaitForUpdate (newState));
+  EXPECT_EQ (newState, "new state");
+}
+
+TEST_F (RpcUpdateWaiterTests, ClientTimeout)
+{
+  EnableShortTimeout ();
+
+  Json::Value newState;
+  EXPECT_FALSE (waiter.WaitForUpdate (newState));
+}
+
+TEST_F (RpcUpdateWaiterTests, ConcurrentCalls)
+{
+  EXPECT_DEATH (
+    {
+      std::thread asyncCall([this] ()
+        {
+          Json::Value newState;
+          waiter.WaitForUpdate (newState);
+        });
+
+      Json::Value newState;
+      waiter.WaitForUpdate (newState);
+    }, "Concurrent calls");
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace charon

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -1,6 +1,6 @@
 /*
     Charon - a transport system for GSP data
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -20,6 +20,7 @@
 #define CHARON_SERVER_HPP
 
 #include "rpcserver.hpp"
+#include "waiterthread.hpp"
 
 #include <memory>
 #include <string>
@@ -47,6 +48,9 @@ private:
    */
   std::unique_ptr<IqAnsweringClient> client;
 
+  /** Whether or not we have a pubsub service.  */
+  bool hasPubSub = false;
+
 public:
 
   explicit Server (RpcServer& b);
@@ -64,9 +68,24 @@ public:
                 int priority);
 
   /**
+   * Adds a pubsub service that can be used for notifications on the XMPP
+   * server we are connected to.
+   */
+  void AddPubSub (const std::string& service);
+
+  /**
    * Disconnects the XMPP client and stops processing requests.
    */
   void Disconnect ();
+
+  /**
+   * Starts serving a new notification on the server.  This must only be called
+   * if we have a pubsub service enabled.
+   *
+   * Returns the pubsub node that has been created for updates on this
+   * notification type.
+   */
+  std::string AddNotification (std::unique_ptr<WaiterThread> upd);
 
 };
 

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -31,6 +31,7 @@ namespace charon
 {
 
 const char* const XMPP_SERVER = "chat.xaya.io";
+const char* const PUBSUB_SERVICE = "pubsub.chat.xaya.io";
 
 /**
  * Our test accounts.  They are all set up for XID on mainnet, and the address

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -176,6 +176,12 @@ UpdatableState::Notification::ExtractStateId (
 }
 
 Json::Value
+UpdatableState::Notification::AlwaysBlockId () const
+{
+  return "always block";
+}
+
+Json::Value
 UpdatableState::GetStateJson (const std::string& id, const std::string& value)
 {
   Json::Value res(Json::objectValue);

--- a/src/testutils.cpp
+++ b/src/testutils.cpp
@@ -1,6 +1,6 @@
 /*
     Charon - a transport system for GSP data
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -23,12 +23,15 @@
 
 #include <glog/logging.h>
 
+#include <chrono>
 #include <sstream>
 
 using testing::IsEmpty;
 
 namespace charon
 {
+
+/* ************************************************************************** */
 
 const char* const XMPP_SERVER = "chat.xaya.io";
 const char* const PUBSUB_SERVICE = "pubsub.chat.xaya.io";
@@ -79,6 +82,8 @@ ParseJson (const std::string& str)
   return res;
 }
 
+/* ************************************************************************** */
+
 Json::Value
 TestBackend::HandleMethod (const std::string& method, const Json::Value& params)
 {
@@ -94,6 +99,8 @@ TestBackend::HandleMethod (const std::string& method, const Json::Value& params)
 
   LOG (FATAL) << "Unexpected method: " << method;
 }
+
+/* ************************************************************************** */
 
 ReceivedMessages::~ReceivedMessages ()
 {
@@ -121,5 +128,79 @@ ReceivedMessages::Expect (const std::vector<std::string>& expected)
   EXPECT_EQ (messages, expected);
   messages.clear ();
 }
+
+/* ************************************************************************** */
+
+/**
+ * UpdateWaiter implementation for the UpdatableState.
+ */
+class UpdatableState::Waiter : public UpdateWaiter
+{
+
+private:
+
+  /** The underlying state.  */
+  UpdatableState& ref;
+
+public:
+
+  explicit Waiter (UpdatableState& s)
+    : ref(s)
+  {}
+
+  bool
+  WaitForUpdate (Json::Value& newState) override
+  {
+    std::unique_lock<std::mutex> lock(ref.mut);
+
+    ++ref.waitCounter;
+    if (ref.waitCounter % 2 == 0)
+      return false;
+
+    ref.cv.wait_for (lock, std::chrono::milliseconds (10));
+
+    newState = ref.state;
+    return !ref.state.isNull ();
+  }
+
+};
+
+Json::Value
+UpdatableState::Notification::ExtractStateId (
+    const Json::Value& fullState) const
+{
+  CHECK (fullState.isObject ());
+  const auto& id = fullState["id"];
+  CHECK (id.isString ());
+  return id;
+}
+
+Json::Value
+UpdatableState::GetStateJson (const std::string& id, const std::string& value)
+{
+  Json::Value res(Json::objectValue);
+  res["id"] = id;
+  res["value"] = value;
+
+  return res;
+}
+
+void
+UpdatableState::SetState (const std::string& id, const std::string& value)
+{
+  LOG (INFO) << "Setting new state: " << id << ", " << value;
+  std::lock_guard<std::mutex> lock(mut);
+  state = GetStateJson (id, value);
+  cv.notify_all ();
+}
+
+std::unique_ptr<WaiterThread>
+UpdatableState::NewWaiter (const std::string& type)
+{
+  return std::make_unique<WaiterThread> (std::make_unique<Notification> (type),
+                                         std::make_unique<Waiter> (*this));
+}
+
+/* ************************************************************************** */
 
 } // namespace charon

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -204,6 +204,7 @@ public:
   {}
 
   Json::Value ExtractStateId (const Json::Value& fullState) const override;
+  Json::Value AlwaysBlockId () const override;
 
 };
 

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -1,6 +1,6 @@
 /*
     Charon - a transport system for GSP data
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -20,12 +20,14 @@
 #define CHARON_TESTUTILS_HPP
 
 #include "rpcserver.hpp"
+#include "waiterthread.hpp"
 
 #include <gloox/jid.h>
 
 #include <json/json.h>
 
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -127,6 +129,81 @@ public:
    * arrive as needed, and clears out the message queue at the end.
    */
   void Expect (const std::vector<std::string>& expected);
+
+};
+
+/**
+ * Fake implementation of an external "game state", that can be updated on
+ * demand and which can serve as "backend" for update notifications in the
+ * server (e.g. as waitforchange source for the backend GSP).
+ *
+ * For tests, we use state in the JSON form {"id":"foo", "value":"bar"}, where
+ * "foo" is the identifier of the state, and "bar" some other value to make
+ * it comparable and distinguishable as needed in tests.
+ */
+class UpdatableState
+{
+
+private:
+
+  class Waiter;
+
+  /** The current state JSON.  */
+  Json::Value state;
+
+  /** Mutex for the instance and waiters.  */
+  std::mutex mut;
+
+  /** Condition variable for the waiting threads.  */
+  std::condition_variable cv;
+
+  /**
+   * Counter for calls to WaitForChange.  This is used to make the call fail
+   * every second time, so we can verify this is tolerated.
+   */
+  unsigned waitCounter = 0;
+
+public:
+
+  class Notification;
+
+  UpdatableState () = default;
+
+  UpdatableState (const UpdatableState&) = delete;
+  void operator= (const UpdatableState&) = delete;
+
+  /**
+   * Constructs a new WaiterThread instance with the given type string
+   * and waiting for updates on this state.
+   */
+  std::unique_ptr<WaiterThread> NewWaiter (const std::string& type);
+
+  /**
+   * Updates the current state.
+   */
+  void SetState (const std::string& id, const std::string& value);
+
+  /**
+   * Constructs the state JSON in our test format for a given ID and value.
+   */
+  static Json::Value GetStateJson (const std::string& id,
+                                   const std::string& value);
+
+};
+
+/**
+ * Test notification type for our UpdatableState.
+ */
+class UpdatableState::Notification : public NotificationType
+{
+
+public:
+
+  explicit Notification (const std::string& type)
+    : NotificationType (type)
+  {}
+
+  Json::Value ExtractStateId (const Json::Value& fullState) const override;
 
 };
 

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -36,6 +36,9 @@ namespace charon
 /** XMPP server used for testing.  */
 extern const char* const XMPP_SERVER;
 
+/** Pubsub service at the server.  */
+extern const char* const PUBSUB_SERVICE;
+
 /**
  * Data for one of the test accounts that we use.
  */

--- a/src/waiterthread.cpp
+++ b/src/waiterthread.cpp
@@ -1,0 +1,99 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "waiterthread.hpp"
+
+#include <glog/logging.h>
+
+namespace charon
+{
+
+WaiterThread::~WaiterThread ()
+{
+  CHECK (loop == nullptr);
+}
+
+void
+WaiterThread::RunLoop ()
+{
+  while (!shouldStop)
+    {
+      Json::Value result;
+      if (!waiter->WaitForUpdate (result))
+        continue;
+
+      std::lock_guard<std::mutex> lock(mut);
+      const Json::Value newId = type->ExtractStateId (result);
+
+      if (!currentState.isNull ()
+            && type->ExtractStateId (currentState) == newId)
+        continue;
+
+      VLOG (1)
+          << "Found new best state ID for " << type->GetType ()
+          << ": " << newId;
+      currentState = result;
+
+      if (cb)
+        cb (currentState);
+    }
+}
+
+void
+WaiterThread::Start ()
+{
+  CHECK (loop == nullptr);
+  LOG (INFO) << "Starting waiter thread for " << type->GetType () << "...";
+
+  currentState = Json::Value ();
+  shouldStop = false;
+  loop = std::make_unique<std::thread> ([this] ()
+    {
+      RunLoop ();
+    });
+}
+
+void
+WaiterThread::Stop ()
+{
+  if (loop == nullptr)
+    return;
+
+  LOG (INFO) << "Stopping waiter thread for " << type->GetType () << "...";
+
+  shouldStop = true;
+  loop->join ();
+  loop.reset ();
+}
+
+Json::Value
+WaiterThread::GetCurrentState () const
+{
+  CHECK (loop != nullptr);
+  std::lock_guard<std::mutex> lock(mut);
+  return currentState;
+}
+
+void
+WaiterThread::SetUpdateHandler (const UpdateHandler& h)
+{
+  std::lock_guard<std::mutex> lock(mut);
+  cb = h;
+}
+
+} // namespace charon

--- a/src/waiterthread.hpp
+++ b/src/waiterthread.hpp
@@ -1,0 +1,160 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef CHARON_WAITERTHREAD_HPP
+#define CHARON_WAITERTHREAD_HPP
+
+#include "notifications.hpp"
+
+#include <json/json.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace charon
+{
+
+/**
+ * Interface for a method to wait for updates to some state in the backend GSP.
+ * This can simply be an RPC call to e.g. waitforchange, but it can also be
+ * implemented e.g. as a direct method call on a libxayagame Game object.
+ */
+class UpdateWaiter
+{
+
+public:
+
+  UpdateWaiter () = default;
+  virtual ~UpdateWaiter () = default;
+
+  /**
+   * Subclasses must implement this method to wait for an update of the state.
+   * The method should return true if the call was successful and we may have
+   * a new state in the output argument.  If it returns false, it means that
+   * the call may be retried, e.g. because of a timeout error.
+   */
+  virtual bool WaitForUpdate (Json::Value& newState) = 0;
+
+};
+
+/**
+ * A thread that waits for updates in the GSP using a "long-polling"
+ * UpdateWaiter instance.  It just keeps calling in a loop, and keeps its own
+ * internal record of the current state.
+ */
+class WaiterThread
+{
+
+public:
+
+  /** Type of callback for state changes.  */
+  using UpdateHandler = std::function<void (const Json::Value& newState)>;
+
+private:
+
+  /** NotificationType that this is for.  */
+  std::unique_ptr<NotificationType> type;
+
+  /** UpdateWaiter we use.  */
+  std::unique_ptr<UpdateWaiter> waiter;
+
+  /** The running loop thread if any.  */
+  std::unique_ptr<std::thread> loop;
+
+  /**
+   * Mutex for the state that is accessed from multiple threads (like the
+   * currentState value).
+   */
+  mutable std::mutex mut;
+
+  /** Set to true if the loop should stop.  */
+  std::atomic<bool> shouldStop;
+
+  /**
+   * Current state from the polling loop.  May be JSON null when we have
+   * just started the loop and not yet received an update.
+   */
+  Json::Value currentState;
+
+  /** Callback to be invoked whenever the state changes.  */
+  UpdateHandler cb;
+
+  /**
+   * Performs the waiting loop.  This is what the loop thread executes.
+   */
+  void RunLoop ();
+
+public:
+
+  /**
+   * Constructs the thread, which is not yet running.
+   */
+  explicit WaiterThread (std::unique_ptr<NotificationType> t,
+                         std::unique_ptr<UpdateWaiter> w)
+    : type(std::move (t)), waiter(std::move (w))
+  {}
+
+  WaiterThread () = delete;
+  WaiterThread (const WaiterThread&) = delete;
+  void operator= (const WaiterThread&) = delete;
+
+  /**
+   * The destructor verifies that the loop is no longer running.  Before
+   * the object is destroyed, the running loop must be stopped explicitly.
+   */
+  virtual ~WaiterThread ();
+
+  /**
+   * Starts the waiter thread loop.
+   */
+  void Start ();
+
+  /**
+   * Stops the threading loop.
+   */
+  void Stop ();
+
+  /**
+   * Returns the notification type name.
+   */
+  const std::string&
+  GetType () const
+  {
+    return type->GetType ();
+  }
+
+  /**
+   * Returns the current state in a non-blocking way.
+   */
+  Json::Value GetCurrentState () const;
+
+  /**
+   * Sets / replaces the handler for updates.
+   */
+  void SetUpdateHandler (const UpdateHandler& h);
+
+};
+
+} // namespace charon
+
+#endif // CHARON_WAITERTHREAD_HPP

--- a/src/waiterthread_tests.cpp
+++ b/src/waiterthread_tests.cpp
@@ -1,0 +1,158 @@
+/*
+    Charon - a transport system for GSP data
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "waiterthread.hpp"
+
+#include "testutils.hpp"
+
+#include <gtest/gtest.h>
+
+#include <glog/logging.h>
+
+#include <chrono>
+
+namespace charon
+{
+namespace
+{
+
+/* ************************************************************************** */
+
+/**
+ * An instance of an UpdatableState, its WaiterThread and an associated
+ * update handler that allows expecting update calls.
+ */
+class TestWaiter : public UpdatableState
+{
+
+private:
+
+  /** The WaiterThread instance from our state.  */
+  std::unique_ptr<WaiterThread> thread;
+
+  /** Mutex for the callback state and cv.  */
+  std::mutex mut;
+
+  /** State with which the update callback was last invoked.  */
+  Json::Value lastCbState;
+
+  /** Condition variable for update callbacks.  */
+  std::condition_variable cv;
+
+public:
+
+  explicit TestWaiter (const std::string& nm)
+  {
+    thread = NewWaiter (nm);
+    thread->SetUpdateHandler ([this] (const Json::Value& s)
+      {
+        VLOG (1) << "Update callback: " << s;
+
+        std::lock_guard<std::mutex> lock(mut);
+
+        EXPECT_TRUE (lastCbState.isNull ()) << "Extra update callback";
+        lastCbState = s;
+
+        cv.notify_all ();
+      });
+
+    thread->Start ();
+    std::this_thread::sleep_for (std::chrono::milliseconds (10));
+  }
+
+  ~TestWaiter ()
+  {
+    thread->Stop ();
+  }
+
+  /**
+   * Returns the current state.
+   */
+  Json::Value
+  GetCurrentState () const
+  {
+    return thread->GetCurrentState ();
+  }
+
+  /**
+   * Expects an update callback for the given new state.
+   */
+  void
+  ExpectUpdate (const std::string& id, const std::string& value)
+  {
+    LOG (INFO) << "Expecting update to: " << id << ", " << value;
+    std::unique_lock<std::mutex> lock(mut);
+    while (true)
+      {
+        if (!lastCbState.isNull ())
+          {
+            EXPECT_EQ (lastCbState, GetStateJson (id, value));
+            lastCbState = Json::Value ();
+            return;
+          }
+
+        cv.wait (lock);
+      }
+  }
+
+};
+
+/* ************************************************************************** */
+
+using WaiterThreadTests = testing::Test;
+
+TEST_F (WaiterThreadTests, Update)
+{
+  TestWaiter w("test");
+  w.SetState ("first", "foo");
+  w.ExpectUpdate ("first", "foo");
+  EXPECT_EQ (w.GetCurrentState (), ParseJson (R"({
+    "id": "first",
+    "value": "foo"
+  })"));
+
+  w.SetState ("second", "bar");
+  w.ExpectUpdate ("second", "bar");
+
+  /* The same ID should not trigger another upate.  */
+  w.SetState ("second", "baz");
+
+  w.SetState ("third", "final");
+  w.ExpectUpdate ("third", "final");
+}
+
+TEST_F (WaiterThreadTests, TwoWaiters)
+{
+  TestWaiter w1("test 1");
+  TestWaiter w2("test 2");
+
+  w1.SetState ("first", "1");
+  w2.SetState ("first", "2");
+  w1.ExpectUpdate ("first", "1");
+  w2.ExpectUpdate ("first", "2");
+
+  w1.SetState ("second", "1");
+  w2.SetState ("second", "2");
+  w1.ExpectUpdate ("second", "1");
+  w2.ExpectUpdate ("second", "2");
+}
+
+/* ************************************************************************** */
+
+} // anonymous namespace
+} // namespace charon

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,6 @@
 REGTESTS = \
-  basic_calls.py
+  basic_calls.py \
+  waitforchange.py
 
 noinst_PYTHON = $(REGTESTS) \
   charonbin.py \

--- a/test/charonbin.py
+++ b/test/charonbin.py
@@ -1,5 +1,5 @@
 #   Charon - a transport system for GSP data
-#   Copyright (C) 2019  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -70,6 +70,7 @@ class Client ():
     args.extend (["--server_jid", self.serverJid])
     args.extend (["--password", self.password])
     args.extend (["--methods", ",".join (self.methods)])
+    args.extend (["--waitforchange"])
 
     envVars = dict (os.environ)
     envVars["GLOG_log_dir"] = self.basedir
@@ -85,7 +86,7 @@ class Client ():
     assert self.proc is not None
 
     self.log.info ("Stopping charon-client process...")
-    self.rpc._notify.stop ()
+    self.proc.terminate ()
     self.proc.wait ()
     self.proc = None
 
@@ -104,7 +105,7 @@ class Server ():
   """
 
   def __init__ (self, basedir, binary, methods, backendRpcUrl,
-                serverJid, password):
+                serverJid, password, pubsub):
     """
     Constructs the manager, which will run the charon-server binary located
     at the given path, setting its log directory and other variables as given.
@@ -118,6 +119,7 @@ class Server ():
     self.backendRpcUrl = backendRpcUrl
     self.serverJid = serverJid
     self.password = password
+    self.pubsub = pubsub
 
     self.proc = None
 
@@ -130,7 +132,9 @@ class Server ():
     args.extend (["--backend_rpc_url", self.backendRpcUrl])
     args.extend (["--server_jid", self.serverJid])
     args.extend (["--password", self.password])
+    args.extend (["--pubsub_service", self.pubsub])
     args.extend (["--methods", ",".join (self.methods)])
+    args.extend (["--waitforchange"])
 
     envVars = dict (os.environ)
     envVars["GLOG_log_dir"] = self.basedir

--- a/test/testcase.py
+++ b/test/testcase.py
@@ -1,5 +1,5 @@
 #   Charon - a transport system for GSP data
-#   Copyright (C) 2019  Autonomous Worlds Ltd
+#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -45,6 +45,7 @@ TEST_ACCOUNTS = [
                 "4C4OpqSlTpx8OG6xtFjCUMLh/AGA=="),
 ]
 XMPP_SERVER = "chat.xaya.io"
+PUBSUB = "pubsub.chat.xaya.io"
 
 
 class Fixture (object):
@@ -132,7 +133,7 @@ class Fixture (object):
     with rpcserver.Server (("localhost", port), obj), \
          charonbin.Server (self.basedir, binary, self.methods, backend,
                            self.getAccountJid (TEST_ACCOUNTS[0]),
-                           TEST_ACCOUNTS[0][1]):
+                           TEST_ACCOUNTS[0][1], PUBSUB):
       yield
 
   def assertEqual (self, a, b):

--- a/test/waitforchange.py
+++ b/test/waitforchange.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python2
+
+#   Charon - a transport system for GSP data
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests relaying of notifications (waitforchange) through the Charon
+binary utils.
+"""
+
+import testcase
+
+import threading
+import time
+
+
+class Methods:
+  """
+  The RPC backend, which supports waitforchange calls.  The caller will
+  be blocked until we explicitly specify a new state.
+
+  This is also a context manager.  On exit, we stop waiting and wake up
+  all possibly still waiting threads.
+  """
+
+  def __init__ (self):
+    self.cv = threading.Condition ()
+    self.state = ""
+    self.waitEnabled = False
+
+  def __enter__ (self):
+    with self.cv:
+      self.waitEnabled = True
+    return self
+
+  def __exit__ (self, exc, value, traceback):
+    with self.cv:
+      self.waitEnabled = False
+      self.cv.notifyAll ()
+
+  def waitforchange (self, known):
+    assert known == ""
+    with self.cv:
+      if self.waitEnabled:
+        self.cv.wait ()
+      return self.state
+
+  def update (self, newState):
+    with self.cv:
+      self.state = newState
+      self.cv.notifyAll ()
+
+
+class Waiter:
+  """
+  Async call to a waitforchange method, which allows waiting for its result
+  and checking that the result is as expected.
+  """
+
+  def __init__ (self, fcn, *args):
+    def task ():
+      self.result = fcn (*args)
+
+    self.thread = threading.Thread (target=task)
+    self.thread.start ()
+
+  def assertRunning (self):
+    time.sleep (0.1)
+    assert self.thread.isAlive ()
+
+  def await (self):
+    self.thread.join ()
+    return self.result
+
+
+with Methods () as backend, \
+     testcase.Fixture ([]) as t, \
+     t.runClient () as c:
+
+  with t.runServer (backend):
+    t.mainLogger.info ("Testing waitforchange update...")
+
+    w = Waiter (c.rpc.waitforchange, "")
+
+    # Give the client time to finish selecting the server.  This has only
+    # been triggered by the first call above.
+    time.sleep (1)
+
+    w.assertRunning ()
+    backend.update ("first")
+    t.assertEqual (w.await (), "first")
+
+    w = Waiter (c.rpc.waitforchange, "other")
+    t.assertEqual (w.await (), "first")
+
+    w = Waiter (c.rpc.waitforchange, "")
+    w.assertRunning ()
+    backend.update ("second")
+    t.assertEqual (w.await (), "second")
+
+  t.mainLogger.info ("Testing server reselection...")
+  with t.runServer (backend):
+    w = Waiter (c.rpc.waitforchange, "")
+    time.sleep (1)
+
+    w.assertRunning ()
+    backend.update ("third")
+    t.assertEqual (w.await (), "third")


### PR DESCRIPTION
This adds support for relaying "updatable states" through Charon, i.e. `waitforchange` and `waitforpendingchange` (#4).  This is done through XMPP PubSub (XEP-0060).