### PR TITLE
Extend method specification for utilities

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,3 +9,4 @@ noinst_PYTHON = $(REGTESTS) \
   testcase.py
 
 TESTS = $(REGTESTS)
+EXTRA_DIST = testspec.json

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,6 @@
 REGTESTS = \
   basic_calls.py \
+  method_selection.py \
   waitforchange.py
 
 noinst_PYTHON = $(REGTESTS) \

--- a/test/charonbin.py
+++ b/test/charonbin.py
@@ -39,7 +39,8 @@ class Client ():
   """
 
   def __init__ (self, basedir, binary, port, methods,
-                serverJid, clientJid, password):
+                serverJid, clientJid, password,
+                extraArgs):
     """
     Constructs the manager, which will run the charon-client binary located
     at the given path, setting its log directory and JSON-RPC port as provided.
@@ -54,6 +55,7 @@ class Client ():
     self.serverJid = serverJid
     self.clientJid = clientJid
     self.password = password
+    self.extraArgs = extraArgs
 
     self.rpcurl = "http://localhost:%d" % port
     self.proc = None
@@ -71,6 +73,7 @@ class Client ():
     args.extend (["--password", self.password])
     args.extend (["--methods", ",".join (self.methods)])
     args.extend (["--waitforchange"])
+    args.extend (self.extraArgs)
 
     envVars = dict (os.environ)
     envVars["GLOG_log_dir"] = self.basedir
@@ -105,7 +108,8 @@ class Server ():
   """
 
   def __init__ (self, basedir, binary, methods, backendRpcUrl,
-                serverJid, password, pubsub):
+                serverJid, password, pubsub,
+                extraArgs):
     """
     Constructs the manager, which will run the charon-server binary located
     at the given path, setting its log directory and other variables as given.
@@ -120,6 +124,7 @@ class Server ():
     self.serverJid = serverJid
     self.password = password
     self.pubsub = pubsub
+    self.extraArgs = extraArgs
 
     self.proc = None
 
@@ -135,6 +140,7 @@ class Server ():
     args.extend (["--pubsub_service", self.pubsub])
     args.extend (["--methods", ",".join (self.methods)])
     args.extend (["--waitforchange"])
+    args.extend (self.extraArgs)
 
     envVars = dict (os.environ)
     envVars["GLOG_log_dir"] = self.basedir

--- a/test/method_selection.py
+++ b/test/method_selection.py
@@ -22,6 +22,9 @@ Tests the method-selection args for the utility binaries.
 
 import testcase
 
+import os
+import os.path
+
 
 class Methods:
 
@@ -58,3 +61,10 @@ with testcase.Fixture ([]) as t:
 
   t.mainLogger.info ("With --methods and --methods_exclude...")
   test (t, ["echo", "doNotCall"], ["--methods_exclude", "doNotCall"])
+
+  t.mainLogger.info ("JSON specification...")
+  srcDir = os.getenv ("srcdir")
+  if not srcDir:
+    srcDir = "."
+  specFile = os.path.join (srcDir, "testspec.json")
+  test (t, [], ["--methods_json_spec", specFile])

--- a/test/method_selection.py
+++ b/test/method_selection.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python2
+
+#   Charon - a transport system for GSP data
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests the method-selection args for the utility binaries.
+"""
+
+import testcase
+
+
+class Methods:
+
+  def echo (self, val):
+    return val
+
+  def doNotCall (self):
+    raise AssertionError ("invalid forwarded call")
+
+
+def test (t, methods, extraArgs):
+  """
+  Runs one round of testing, using the specified methods array
+  and extraArgs.  The configuration should always result in the
+  "echo" method being available and the "doNotCall" method not being
+  available.
+  """
+
+  with t.runClient (methods=methods, extraArgs=extraArgs) as c, \
+       t.runServer (backend, methods=methods, extraArgs=extraArgs):
+
+    t.log.info ("Testing successful call forwarding...")
+    t.assertEqual (c.rpc.echo ("bla"), "bla")
+
+    t.log.info ("Unsupported method...")
+    t.expectRpcError (".*METHOD_NOT_FOUND.*", c.rpc.doNotCall)
+
+
+backend = Methods ()
+with testcase.Fixture ([]) as t:
+
+  t.mainLogger.info ("Just --methods...")
+  test (t, ["echo"], [])
+
+  t.mainLogger.info ("With --methods and --methods_exclude...")
+  test (t, ["echo", "doNotCall"], ["--methods_exclude", "doNotCall"])

--- a/test/testcase.py
+++ b/test/testcase.py
@@ -105,7 +105,7 @@ class Fixture (object):
 
     logging.shutdown ()
 
-  def runClient (self):
+  def runClient (self, methods=None, extraArgs=[]):
     """
     Returns a context manager for running a Charon client in our environment.
     """
@@ -113,13 +113,17 @@ class Fixture (object):
     binary = os.path.join (self.bindir, "charon-client")
     port = self.getNextPort ()
 
-    return charonbin.Client (self.basedir, binary, port, self.methods,
+    if methods is None:
+      methods = self.methods
+
+    return charonbin.Client (self.basedir, binary, port, methods,
                              self.getAccountJid (TEST_ACCOUNTS[0]),
                              self.getAccountJid (TEST_ACCOUNTS[1]),
-                             TEST_ACCOUNTS[1][1])
+                             TEST_ACCOUNTS[1][1],
+                             extraArgs)
 
   @contextmanager
-  def runServer (self, obj):
+  def runServer (self, obj, methods=None, extraArgs=[]):
     """
     Returns a context manager for running a Charon server in our environment.
     It will start a fresh JSON-RPC server as backend, exposing all the members
@@ -130,10 +134,14 @@ class Fixture (object):
     port = self.getNextPort ()
     backend = "http://localhost:%d" % port
 
+    if methods is None:
+      methods = self.methods
+
     with rpcserver.Server (("localhost", port), obj), \
-         charonbin.Server (self.basedir, binary, self.methods, backend,
+         charonbin.Server (self.basedir, binary, methods, backend,
                            self.getAccountJid (TEST_ACCOUNTS[0]),
-                           TEST_ACCOUNTS[0][1], PUBSUB):
+                           TEST_ACCOUNTS[0][1], PUBSUB,
+                           extraArgs):
       yield
 
   def assertEqual (self, a, b):

--- a/test/testspec.json
+++ b/test/testspec.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "echo",
+    "params": [10],
+    "returns": 10
+  },
+  {
+    "name": "doNotCall",
+    "params":
+      {
+        "value": 10
+      }
+  }
+]

--- a/util/methods.hpp
+++ b/util/methods.hpp
@@ -1,6 +1,6 @@
 /*
     Charon - a transport system for GSP data
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -26,7 +26,8 @@ namespace charon
 {
 
 /**
- * Returns the set of methods selected by --methods.
+ * Returns the set of methods selected by the corresponding command-line
+ * arguments.
  */
 std::set<std::string> GetSelectedMethods ();
 


### PR DESCRIPTION
This extends the ways in which the exposed methods can be controlled / specified for the utility binaries (`charon-server` and `charon-client`).  In particular, we allow specifying them through the libjson-rpc-cpp stubgen JSON file.  This makes it easy to just "expose all methods" in basic situations.