### PR TITLE
Implement backend version check

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -33,13 +33,15 @@ receives such a message and feels ready to accept another client (i.e. is not
 overloaded) will reply with a directed presence as acknowledgement:
 
     <presence to="player@server/resource">
-      <pong xmlns="https://xaya.io/charon/" />
+      <pong xmlns="https://xaya.io/charon/" version="backend version" />
     </presence>
 
 The client can then select one of the replies it gets (in case there are
 multiple) and record the GSP client's full JID (including its resource)
-for further requests.  Once a server is selected, the client will send
-a directed presence as well:
+for further requests.  It can also take the backend version provided by
+the server into account, in case it wants to ensure a particular set of
+consensus rules (while a fork is going on) or interface.
+Once a server is selected, the client will send a directed presence as well:
 
     <presence to="gsp@server/resource" />
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -579,8 +579,16 @@ Client::Impl::handlePresence (const gloox::Presence& p)
     case gloox::Presence::Available:
       {
         const auto* pong = p.findExtension<PongMessage> (PongMessage::EXT_TYPE);
-        if (pong == nullptr)
+        if (pong == nullptr || !pong->IsValid ())
           return;
+        if (pong->GetVersion () != client.version)
+          {
+            LOG (WARNING)
+                << "Server " << p.from ().full ()
+                << " reported version " << pong->GetVersion ()
+                << " while we want " << client.version;
+            return;
+          }
 
         const auto* sn = p.findExtension<SupportedNotifications> (
             SupportedNotifications::EXT_TYPE);
@@ -786,8 +794,8 @@ Client::Impl::WaitForChange (const std::string& type, const Json::Value& known)
 
 /* ************************************************************************** */
 
-Client::Client (const std::string& srv)
-  : serverJid(srv)
+Client::Client (const std::string& srv, const std::string& v)
+  : serverJid(srv), version(v)
 {
   SetTimeout (DEFAULT_TIMEOUT);
 }

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -50,6 +50,9 @@ private:
   /** The user-chosen server JID, which is typically just a bare JID.  */
   std::string serverJid;
 
+  /** The expected server version string.  */
+  std::string version;
+
   /** Current timeout when waiting for replies of the server JID.  */
   Duration timeout;
 
@@ -72,7 +75,7 @@ public:
    * made (after the instance is connected) will be forwarded to the given
    * JID for reply.
    */
-  explicit Client (const std::string& srv);
+  explicit Client (const std::string& srv, const std::string& v);
 
   ~Client ();
 

--- a/src/client_tests.cpp
+++ b/src/client_tests.cpp
@@ -266,7 +266,7 @@ protected:
   std::unique_ptr<Server>
   ConnectServer (const std::string& ressource="")
   {
-    auto res = std::make_unique<Server> (backend);
+    auto res = std::make_unique<Server> ("", backend);
     res->Connect (JIDWithResource (accServer, ressource).full (),
                   accServer.password, 0);
     return res;

--- a/src/client_tests.cpp
+++ b/src/client_tests.cpp
@@ -84,7 +84,7 @@ private:
 
         LOG (INFO) << "Sleep done, sending pong now";
         gloox::Presence reply(gloox::Presence::Available, msg.from ());
-        reply.addExtension (new PongMessage ());
+        reply.addExtension (new PongMessage (serverVersion));
 
         RunWithClient ([&reply] (gloox::Client& c)
           {
@@ -124,12 +124,16 @@ protected:
   static constexpr const TestAccount& accServer = ACCOUNTS[0];
   static constexpr const TestAccount& accClient = ACCOUNTS[1];
   static constexpr const char* SERVER_RES = "test";
+  static constexpr const char* SERVER_VERSION = "version";
 
   Client client;
 
+  /** The version string to return by the server.  */
+  std::string serverVersion = SERVER_VERSION;
+
   ClientServerDiscoveryTests ()
     : XmppClient(JIDWithResource (accServer, SERVER_RES), accServer.password),
-      client(JIDWithoutResource (accServer).bare ())
+      client(JIDWithoutResource (accServer).bare (), SERVER_VERSION)
   {
     RunWithClient ([this] (gloox::Client& c)
       {
@@ -167,6 +171,13 @@ TEST_F (ClientServerDiscoveryTests, FindsServerResource)
   client.SetTimeout (2 * PONG_DELAY);
   EXPECT_EQ (client.GetServerResource (), SERVER_RES);
   ExpectClientPresence ();
+}
+
+TEST_F (ClientServerDiscoveryTests, VersionMismatch)
+{
+  serverVersion = std::string ("not ") + SERVER_VERSION;
+  client.SetTimeout (2 * PONG_DELAY);
+  EXPECT_EQ (client.GetServerResource (), "");
 }
 
 TEST_F (ClientServerDiscoveryTests, Timeout)
@@ -240,6 +251,8 @@ private:
   static constexpr const TestAccount& accServer = ACCOUNTS[0];
   static constexpr const TestAccount& accClient = ACCOUNTS[1];
 
+  static constexpr const char* SERVER_VERSION = "version";
+
 protected:
 
   DelayedTestBackend backend;
@@ -247,7 +260,7 @@ protected:
   Client client;
 
   ClientTestWithServer ()
-    : client(JIDWithoutResource (accServer).bare ())
+    : client(JIDWithoutResource (accServer).bare (), SERVER_VERSION)
   {}
 
   /**
@@ -266,7 +279,7 @@ protected:
   std::unique_ptr<Server>
   ConnectServer (const std::string& ressource="")
   {
-    auto res = std::make_unique<Server> ("", backend);
+    auto res = std::make_unique<Server> (SERVER_VERSION, backend);
     res->Connect (JIDWithResource (accServer, ressource).full (),
                   accServer.password, 0);
     return res;

--- a/src/private/stanzas.hpp
+++ b/src/private/stanzas.hpp
@@ -240,10 +240,15 @@ public:
 /**
  * A gloox StanzaExtension representing a "pong" message/presence:
  *
- *  <pong xmlns="https://xaya.io/charon/" />
+ *  <pong xmlns="https://xaya.io/charon/" version="server version" />
  */
 class PongMessage : public ValidatedStanzaExtension
 {
+
+private:
+
+  /** The server version string.  */
+  std::string version;
 
 public:
 
@@ -252,9 +257,28 @@ public:
 
   /**
    * Constructs an empty instance, which can be used as a factory
-   * as well as a totally valid message.
+   * but is otherwise marked as invalid.
    */
   PongMessage ();
+
+  /**
+   * Constructs a valid instance based on the given version string.
+   */
+  explicit PongMessage (const std::string& v);
+
+  /**
+   * Constructs an instance from a given tag.
+   */
+  explicit PongMessage (const gloox::Tag& t);
+
+  /**
+   * Returns this instance's version string.
+   */
+  const std::string&
+  GetVersion () const
+  {
+    return version;
+  }
 
   const std::string& filterString () const override;
   gloox::StanzaExtension* newInstance (const gloox::Tag* tag) const override;

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -39,6 +39,9 @@ private:
 
   class IqAnsweringClient;
 
+  /** The version string to report.  */
+  const std::string version;
+
   /** The backing RpcServer instance.  */
   RpcServer& backend;
 
@@ -53,7 +56,7 @@ private:
 
 public:
 
-  explicit Server (RpcServer& b);
+  explicit Server (const std::string& v, RpcServer& b);
   ~Server ();
 
   Server () = delete;

--- a/src/stanzas.cpp
+++ b/src/stanzas.cpp
@@ -386,7 +386,24 @@ PingMessage::tag () const
 PongMessage::PongMessage ()
   : ValidatedStanzaExtension(EXT_TYPE)
 {
+  SetValid (false);
+}
+
+PongMessage::PongMessage (const std::string& v)
+  : ValidatedStanzaExtension(EXT_TYPE),
+    version(v)
+{
   SetValid (true);
+}
+
+PongMessage::PongMessage (const gloox::Tag& t)
+  : ValidatedStanzaExtension(EXT_TYPE)
+{
+  SetValid (true);
+
+  /* If the attribute is not present, then we assume an empty version.
+     This is totally fine.  */
+  version = t.findAttribute ("version");
 }
 
 const std::string&
@@ -399,13 +416,13 @@ PongMessage::filterString () const
 gloox::StanzaExtension*
 PongMessage::newInstance (const gloox::Tag* tag) const
 {
-  return new PongMessage ();
+  return new PongMessage (*tag);
 }
 
 gloox::StanzaExtension*
 PongMessage::clone () const
 {
-  return new PongMessage ();
+  return new PongMessage (version);
 }
 
 gloox::Tag*
@@ -413,6 +430,8 @@ PongMessage::tag () const
 {
   auto res = std::make_unique<gloox::Tag> ("pong");
   CHECK (res->setXmlns (XMLNS));
+  if (!version.empty ())
+    CHECK (res->addAttribute ("version", version));
 
   return res.release ();
 }

--- a/src/stanzas_tests.cpp
+++ b/src/stanzas_tests.cpp
@@ -148,6 +148,31 @@ TEST_F (RpcResponseTests, ErrorOnlyCode)
 
 /* ************************************************************************** */
 
+using PongMessageTests = testing::Test;
+
+TEST_F (PongMessageTests, WithoutVersion)
+{
+  PongMessage original("");
+  auto recreated = ExtensionRoundtrip (original);
+
+  ASSERT_TRUE (recreated->IsValid ());
+  EXPECT_EQ (recreated->GetVersion (), "");
+
+  std::unique_ptr<gloox::Tag> tag(original.tag ());
+  EXPECT_FALSE (tag->hasAttribute ("version"));
+}
+
+TEST_F (PongMessageTests, WithVersion)
+{
+  PongMessage original("version");
+  auto recreated = ExtensionRoundtrip (original);
+
+  ASSERT_TRUE (recreated->IsValid ());
+  EXPECT_EQ (recreated->GetVersion (), "version");
+}
+
+/* ************************************************************************** */
+
 using SupportedNotificationsTests = testing::Test;
 
 TEST_F (SupportedNotificationsTests, NoNotifications)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,7 @@
 REGTESTS = \
   basic_calls.py \
   method_selection.py \
+  server_version.py \
   waitforchange.py
 
 noinst_PYTHON = $(REGTESTS) \

--- a/test/server_version.py
+++ b/test/server_version.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python2
+
+#   Charon - a transport system for GSP data
+#   Copyright (C) 2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests selection of the right server if two versions are provided.
+"""
+
+import testcase
+
+
+class Methods:
+
+  def __init__ (self, val):
+    self.returnValue = val
+
+  def test (self):
+    return self.returnValue
+
+
+right = Methods ("right")
+left = Methods ("left")
+
+with testcase.Fixture (["test"]) as t, \
+     t.runServer (right, extraArgs=["--backend_version", "right"]), \
+     t.runServer (left, extraArgs=["--backend_version", "left"]), \
+     t.runClient (extraArgs=["--backend_version", "right"]) as cr, \
+     t.runClient (extraArgs=["--backend_version", "left"]) as cl:
+  t.assertEqual (cr.rpc.test (), "right")
+  t.assertEqual (cl.rpc.test (), "left")

--- a/util/client.cpp
+++ b/util/client.cpp
@@ -43,6 +43,8 @@ namespace
 {
 
 DEFINE_string (server_jid, "", "Bare or full JID for the server");
+DEFINE_string (backend_version, "",
+               "A string identifying the version of the backend required");
 
 DEFINE_string (client_jid, "", "Bare or full JID for the client");
 DEFINE_string (password, "", "XMPP password for the client JID");
@@ -218,7 +220,8 @@ main (int argc, char** argv)
     }
 
   LOG (INFO) << "Using " << FLAGS_server_jid << " as server";
-  charon::Client client(FLAGS_server_jid);
+  LOG (INFO) << "Requiring backend version " << FLAGS_backend_version;
+  charon::Client client(FLAGS_server_jid, FLAGS_backend_version);
 
   LOG (INFO) << "Listening for local RPCs on port " << FLAGS_port;
   jsonrpc::HttpServer httpServer(FLAGS_port);

--- a/util/server.cpp
+++ b/util/server.cpp
@@ -40,6 +40,8 @@ namespace
 
 DEFINE_string (backend_rpc_url, "",
                "URL at which the backend JSON-RPC interface is available");
+DEFINE_string (backend_version, "",
+               "A string identifying the version of the backend provided");
 
 DEFINE_string (server_jid, "", "Bare or full JID for the server");
 DEFINE_string (password, "", "XMPP password for the server JID");
@@ -91,6 +93,7 @@ main (int argc, char** argv)
   charon::ForwardingRpcServer backend(FLAGS_backend_rpc_url);
   LOG (INFO)
       << "Forwarding calls to JSON-RPC server at " << FLAGS_backend_rpc_url;
+  LOG (INFO) << "Reporting backend version " << FLAGS_backend_version;
 
   const auto methods = charon::GetSelectedMethods ();
   if (methods.empty ())
@@ -102,7 +105,7 @@ main (int argc, char** argv)
     }
 
   LOG (INFO) << "Connecting server to XMPP as " << FLAGS_server_jid;
-  charon::Server srv(backend);
+  charon::Server srv(FLAGS_backend_version, backend);
   srv.Connect (FLAGS_server_jid, FLAGS_password, FLAGS_priority);
 
   if (FLAGS_pubsub_service.empty ())


### PR DESCRIPTION
This introduces a new concept of "backend version", which is a string that should describe the version of a backend (e.g. consensus forks, interface) provided by a Charon server or required by a Charon client.  The server will advertise its backend version in the pong message, and the client will only accept server pong's that match the required version.

This is useful e.g. when in the process of upgrading a GSP.  The frontend can then ensure it requests a Charon server matching its expected version (e.g. that of the embedded non-light-mode GSP, and/or that supporting some new interface), and temporarily two versions can be running in parallel while people update the frontends.

Fixes #8.