### PR TITLE
Local test environment

### DIFF
--- a/src/pubsub_tests.cpp
+++ b/src/pubsub_tests.cpp
@@ -54,7 +54,7 @@ public:
     : XmppClient(JIDWithResource (acc, res), acc.password)
   {
     Connect (0);
-    AddPubSub (gloox::JID (PUBSUB_SERVICE));
+    AddPubSub (gloox::JID (GetServerConfig ().pubsub));
   }
 
   /**
@@ -110,7 +110,7 @@ protected:
   PubSubClient server;
 
   PubSubTests ()
-    : client(ACCOUNTS[0]), server(ACCOUNTS[1])
+    : client(GetTestAccount (0)), server(GetTestAccount (1))
   {}
 
 };
@@ -157,7 +157,7 @@ TEST_F (PubSubTests, TwoClients)
   const auto node = server.GetPubSub ().CreateNode ();
   ASSERT_TRUE (client.Subscribe (node));
 
-  PubSubClient otherClient(ACCOUNTS[0]);
+  PubSubClient otherClient(GetTestAccount (0));
   ASSERT_TRUE (otherClient.Subscribe (node));
 
   const auto xml1 = server.Publish (node, "tag1", "first");
@@ -174,7 +174,7 @@ TEST_F (PubSubTests, OneClientUnsubscribes)
 
   std::string xml1;
   {
-    PubSubClient otherClient(ACCOUNTS[0]);
+    PubSubClient otherClient(GetTestAccount (0));
     ASSERT_TRUE (otherClient.Subscribe (node));
 
     xml1 = server.Publish (node, "tag1", "first");
@@ -190,7 +190,7 @@ TEST_F (PubSubTests, ClientReconnectNotAutomaticallySubscribed)
   const auto node = server.GetPubSub ().CreateNode ();
 
   {
-    PubSubClient otherClient(ACCOUNTS[0], "res");
+    PubSubClient otherClient(GetTestAccount (0), "res");
     ASSERT_TRUE (otherClient.Subscribe (node));
 
     const auto xml = server.Publish (node, "tag1", "first");
@@ -201,7 +201,7 @@ TEST_F (PubSubTests, ClientReconnectNotAutomaticallySubscribed)
      the node again.  Only after we explicitly subscribe should we receive
      published items again.  */
   {
-    PubSubClient otherClient(ACCOUNTS[0], "res");
+    PubSubClient otherClient(GetTestAccount (0), "res");
     server.Publish (node, "tag2", "second");
 
     ASSERT_TRUE (otherClient.Subscribe (node));
@@ -213,7 +213,7 @@ TEST_F (PubSubTests, ClientReconnectNotAutomaticallySubscribed)
 
 TEST_F (PubSubTests, NodeGoesOffline)
 {
-  PubSubClient otherServer(ACCOUNTS[1]);
+  PubSubClient otherServer(GetTestAccount (1));
   const auto node = otherServer.GetPubSub ().CreateNode ();
   ASSERT_TRUE (client.Subscribe (node));
   /* It is fine that the node goes offline and is deleted before the
@@ -224,7 +224,7 @@ TEST_F (PubSubTests, ServerCleansUpNode)
 {
   std::string node;
   {
-    PubSubClient otherServer(ACCOUNTS[1]);
+    PubSubClient otherServer(GetTestAccount (1));
     node = otherServer.GetPubSub ().CreateNode ();
   }
 
@@ -243,7 +243,7 @@ TEST_F (PubSubTests, TwoServers)
 
   std::vector<std::string> xmls;
   {
-    PubSubClient otherServer(ACCOUNTS[1]);
+    PubSubClient otherServer(GetTestAccount (1));
     const auto node2 = otherServer.GetPubSub ().CreateNode ();
     ASSERT_TRUE (client.Subscribe (node2));
 

--- a/src/testutils.hpp
+++ b/src/testutils.hpp
@@ -35,12 +35,6 @@
 namespace charon
 {
 
-/** XMPP server used for testing.  */
-extern const char* const XMPP_SERVER;
-
-/** Pubsub service at the server.  */
-extern const char* const PUBSUB_SERVICE;
-
 /**
  * Data for one of the test accounts that we use.
  */
@@ -55,8 +49,39 @@ struct TestAccount
 
 };
 
-/** Test accounts on the server.  */
-extern const TestAccount ACCOUNTS[2];
+/**
+ * Full set of "server configuration" used for testing.
+ */
+struct ServerConfiguration
+{
+
+  /** The XMPP server used.  */
+  const char* server;
+
+  /** The pubsub service.  */
+  const char* pubsub;
+
+  /** The test accounts.  */
+  TestAccount accounts[2];
+
+};
+
+/**
+ * Returns the ServerConfiguration instance that should be used throughout
+ * testing.  This can be configured with the environment variable
+ * CHARON_TEST_SERVER.
+ *
+ * By default it is localhost for the local environment (see test/env), but
+ * can also be set to chat.xaya.io for testing against the production
+ * server (and e.g. verifying that the server configuration works for
+ * Charon).
+ */
+const ServerConfiguration& GetServerConfig ();
+
+/**
+ * Returns the n-th TestAccount from the selected server config.
+ */
+const TestAccount& GetTestAccount (unsigned n);
 
 /**
  * Constructs the JID for a test account, without resource.

--- a/src/xmppclient_tests.cpp
+++ b/src/xmppclient_tests.cpp
@@ -105,13 +105,13 @@ using XmppClientTests = testing::Test;
 
 TEST_F (XmppClientTests, Connecting)
 {
-  TestXmppClient client(ACCOUNTS[0]);
+  TestXmppClient client(GetTestAccount (0));
 }
 
 TEST_F (XmppClientTests, Messages)
 {
-  TestXmppClient client1(ACCOUNTS[0]);
-  TestXmppClient client2(ACCOUNTS[1]);
+  TestXmppClient client1(GetTestAccount (0));
+  TestXmppClient client2(GetTestAccount (1));
 
   client1.SendMessage (client2, "foo");
   client1.SendMessage (client2, "bar");

--- a/test/env/README.md
+++ b/test/env/README.md
@@ -1,0 +1,15 @@
+# Testing Environment
+
+For testing Charon, a suitable XMPP server must be running.  This directory
+provides a [Docker Compose](https://docs.docker.com/compose/) configuration
+for starting such a server on localhost.
+
+When run, it starts up a local ejabberd instance for `localhost`
+and with pubsub enabled on `pubsub.localhost`.  Two user accounts
+are available on it, `xmpptest1` and `xmpptest2`, the password for
+both accounts is `password`.
+
+To start up the test environment and clean up the temporary data in
+volumes after it is finished, use simply
+
+    $ ./run.sh

--- a/test/env/docker-compose.yml
+++ b/test/env/docker-compose.yml
@@ -1,0 +1,11 @@
+# Start up a local ejabberd XMPP server with temporary environment
+# for testing Charon.
+
+version: "3"
+
+services:
+
+  ejabberd:
+    build: ./image
+    ports:
+      - "127.0.0.1:5222:5222"

--- a/test/env/image/Dockerfile
+++ b/test/env/image/Dockerfile
@@ -1,0 +1,16 @@
+# Constructs a Docker image of ejabberd with custom configuration to run
+# a local XMPP node for testing Charon against.
+
+FROM ejabberd/ecs
+USER root
+
+WORKDIR $HOME
+COPY ejabberd.yml ejabberdctl.cfg conf/
+COPY run.sh bin/
+
+# Since this is just temporary for testing, we might as well just
+# kill the server quickly.
+STOPSIGNAL SIGKILL
+
+USER ejabberd
+ENTRYPOINT ["/home/ejabberd/bin/run.sh"]

--- a/test/env/image/ejabberd.yml
+++ b/test/env/image/ejabberd.yml
@@ -1,0 +1,78 @@
+# Basic configuration file for running a local ejabberd instance
+# with xid authentication, which is suitable for running Charon tests
+# against it.
+
+hosts:
+  - localhost
+
+loglevel: 4
+log_rotate_size: 10485760
+log_rotate_count: 1
+
+certfiles:
+  - /home/ejabberd/conf/server.pem
+
+# gloox does not work well together with TLSv1.3, so we should avoid
+# using that.
+c2s_protocol_options:
+  - "no_tlsv1_3"
+
+listen:
+  -
+    port: 5222
+    ip: "::"
+    module: ejabberd_c2s
+    max_stanza_size: 262144
+    shaper: c2s_shaper
+    access: c2s
+    starttls_required: true
+
+acl:
+  local:
+    user_regexp: ""
+  loopback:
+    ip:
+      - 127.0.0.0/8
+      - ::1/128
+      - ::FFFF:127.0.0.1/128
+  admin:
+    user:
+      - "admin@localhost"
+
+access_rules:
+  local:
+    allow: local
+  c2s:
+    allow: all
+  configure:
+    allow: admin
+  pubsub_createnode:
+    allow: local
+
+shaper_rules:
+  max_user_offline_messages:
+    - 100
+  c2s_shaper:
+    none: all
+
+max_fsm_queue: 10000
+
+modules:
+  mod_offline:
+    access_max_user_messages: max_user_offline_messages
+  mod_ping: {}
+  mod_pubsub:
+    access_createnode: pubsub_createnode
+    plugins:
+      - flat
+    default_node_config:
+      persist_items: false
+      purge_offline: true
+      access_model: open
+    force_node_config:
+      "*":
+        persist_items: false
+        purge_offline: true
+
+auth_method: internal
+auth_password_format: plain

--- a/test/env/image/ejabberdctl.cfg
+++ b/test/env/image/ejabberdctl.cfg
@@ -1,0 +1,2 @@
+ERLANG_NODE=ejabberd@localhost
+ERLANG_COOKIE=dummycookie

--- a/test/env/image/run.sh
+++ b/test/env/image/run.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+
+ejabberdctl="${HOME}/bin/ejabberdctl"
+
+echo "Starting ejabberd..."
+${ejabberdctl} foreground &
+pid=$!
+while ! ${ejabberdctl} status
+do
+  sleep 1
+done
+
+echo "Registering users..."
+${ejabberdctl} register xmpptest1 localhost password
+${ejabberdctl} register xmpptest2 localhost password
+
+printf "\\n\\nXMPP testing environment started successfully\\n"
+wait ${pid}

--- a/test/env/run.sh
+++ b/test/env/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This is a utility script to start the test environment and clean it
+# up afterwards.
+
+docker-compose up -V --force-recreate
+docker-compose rm -fv


### PR DESCRIPTION
This defines Docker-based scripts for running a local ejabberd server for testing, and uses it by default for unit and integration tests.  Optionally the real production server can be chosen by defining `CHARON_TEST_SERVER=chat.xaya.io` in the environment.  This may be useful to verify the server configuration for Charon.