### PR TITLE
Make the Charon server reconnect to XMPP

### DIFF
--- a/src/client_tests.cpp
+++ b/src/client_tests.cpp
@@ -283,10 +283,13 @@ protected:
   std::unique_ptr<Server>
   ConnectServer (const std::string& ressource="")
   {
-    auto res = std::make_unique<Server> (SERVER_VERSION, backend);
-    res->Connect (
-        JIDWithResource (GetTestAccount (accServer), ressource).full (),
-        GetTestAccount (accServer).password, 0);
+    const auto& acc = GetTestAccount (accServer);
+    auto res = std::make_unique<Server> (
+        SERVER_VERSION, backend,
+        JIDWithResource (acc, ressource).full (),
+        acc.password);
+
+    res->Connect (0);
     return res;
   }
 

--- a/src/private/xmppclient.hpp
+++ b/src/private/xmppclient.hpp
@@ -63,6 +63,13 @@ private:
   /** The gloox XMPP client instance.  */
   gloox::Client client;
 
+  /**
+   * PubSub service to use (if any).  If this is not the empty string,
+   * then a pubsub node will be attached on successful connects and
+   * reconnects automatically.
+   */
+  gloox::JID pubsubService;
+
   /** PubSub instance used by this client.  */
   std::unique_ptr<PubSubImpl> pubsub;
 
@@ -90,6 +97,11 @@ private:
    * receive thread calls repeatedly.
    */
   bool Receive ();
+
+  /**
+   * Attaches the PubSubImpl for our configured service.
+   */
+  void AttachPubSub ();
 
   void onConnect () override;
   void onDisconnect (gloox::ConnectionError err) override;
@@ -142,7 +154,7 @@ public:
 
   /**
    * Gives access to the pubsub instance.  Must only be called if one was
-   * initialised with AddPubSub already.
+   * initialised with AddPubSub already and the server is connected.
    */
   PubSubImpl& GetPubSub ();
 

--- a/src/private/xmppclient.hpp
+++ b/src/private/xmppclient.hpp
@@ -100,6 +100,24 @@ private:
 
   friend class PubSubImpl;
 
+protected:
+
+  /**
+   * Callback that gets triggered when the server either is about to
+   * disconnect (when we do it voluntarily and know about it beforehand),
+   * or when it has been disconnected already and we did not get advance
+   * warning (because e.g. the server just went down).
+   *
+   * The IsConnected() method can be used to check which of these situations
+   * is the case if that's needed.
+   *
+   * This method does nothing by default, but can be used to clean up things
+   * associated to the current connection in subclasses.
+   */
+  virtual void
+  HandleDisconnect ()
+  {}
+
 public:
 
   /**

--- a/src/private/xmppclient.hpp
+++ b/src/private/xmppclient.hpp
@@ -1,6 +1,6 @@
 /*
     Charon - a transport system for GSP data
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -47,6 +47,16 @@ class XmppClient : private gloox::ConnectionListener, private gloox::LogHandler
 
 private:
 
+  /**
+   * Current state of the client.
+   */
+  enum class ConnectionState
+  {
+    DISCONNECTED,
+    CONNECTING,
+    CONNECTED,
+  };
+
   /** Our JID for the connection.  */
   gloox::JID jid;
 
@@ -64,8 +74,8 @@ private:
   /** Signal for the receive loop to stop.  */
   std::atomic<bool> stopLoop;
 
-  /** Set to true when the connection is established.  */
-  std::atomic<bool> connected;
+  /** Current connection state (set by the onConnect/onDisconnect handlers).  */
+  std::atomic<ConnectionState> connectionState;
 
   /**
    * Lock used to synchronise receives and other client accesses.  This has
@@ -122,13 +132,26 @@ public:
    * Sets up the connection to the server, using the specified priority.
    * Once connected, the receiving loop will be started.  The loop will
    * run until the connection is closed.
+   *
+   * Returns true if the connection was opened successfully, and false
+   * if the connection failed (in which case the client will still be
+   * disconnected after return).
    */
-  void Connect (int priority);
+  bool Connect (int priority);
 
   /**
    * Closes the server connection.
    */
   void Disconnect ();
+
+  /**
+   * Returns true if the client is successfully connected.
+   */
+  bool
+  IsConnected () const
+  {
+    return connectionState == ConnectionState::CONNECTED;
+  }
 
   /**
    * Returns the JID of the connected user.

--- a/src/pubsub_tests.cpp
+++ b/src/pubsub_tests.cpp
@@ -1,6 +1,6 @@
 /*
     Charon - a transport system for GSP data
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -138,6 +138,24 @@ TEST_F (PubSubTests, PublishReceive)
   const auto xml2 = server.Publish (node, "othertag", "other text");
 
   client.ExpectItems ({xml1, xml2});
+}
+
+TEST_F (PubSubTests, Reconnects)
+{
+  std::string node = server.GetPubSub ().CreateNode ();
+  ASSERT_TRUE (client.Subscribe (node));
+  const auto xml1 = server.Publish (node, "mytag", "with some text");
+  client.ExpectItems ({xml1});
+
+  client.Disconnect ();
+  server.Disconnect ();
+  client.Connect (0);
+  server.Connect (0);
+
+  node = server.GetPubSub ().CreateNode ();
+  ASSERT_TRUE (client.Subscribe (node));
+  const auto xml2 = server.Publish (node, "othertag", "other text");
+  client.ExpectItems ({xml2});
 }
 
 TEST_F (PubSubTests, SubscribeAfterFirstPublish)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -132,7 +132,7 @@ class Server::IqAnsweringClient : public XmppClient,
 private:
 
   /** The server's version string.  */
-  const std::string& version;
+  const std::string version;
 
   /** The backend server to use for answering requests.  */
   RpcServer& backend;
@@ -304,26 +304,25 @@ Server::IqAnsweringClient::HandleDisconnect ()
   ClearNotifications ();
 }
 
-Server::Server (const std::string& v, RpcServer& b)
-  : version(v), backend(b)
-{}
-
-Server::~Server () = default;
-
-void
-Server::Connect (const std::string& jidStr, const std::string& password,
-                 const int priority)
+Server::Server (const std::string& version, RpcServer& backend,
+                const std::string& jidStr, const std::string& password)
 {
   const gloox::JID jid(jidStr);
   client = std::make_unique<IqAnsweringClient> (version, backend,
                                                 jid, password);
+}
+
+Server::~Server () = default;
+
+void
+Server::Connect (const int priority)
+{
   client->Connect (priority);
 }
 
 void
 Server::AddPubSub (const std::string& service)
 {
-  CHECK (client != nullptr);
   CHECK (!hasPubSub);
 
   const gloox::JID serviceJid(service);
@@ -335,17 +334,12 @@ Server::AddPubSub (const std::string& service)
 void
 Server::Disconnect ()
 {
-  if (client == nullptr)
-    return;
-
   client->Disconnect ();
-  client.reset ();
 }
 
 std::string
 Server::AddNotification (std::unique_ptr<WaiterThread> upd)
 {
-  CHECK (client != nullptr);
   CHECK (hasPubSub);
   return client->AddNotification (std::move (upd));
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -422,17 +422,26 @@ Server::AddNotification (std::unique_ptr<WaiterThread> upd)
   client->AddNotification (std::move (upd));
 }
 
-void
+bool
 Server::Connect (const int priority)
 {
-  client->Connect (priority);
+  if (!client->Connect (priority))
+    return false;
+
   client->ConnectNotifications ();
+  return true;
 }
 
 void
 Server::Disconnect ()
 {
   client->Disconnect ();
+}
+
+bool
+Server::IsConnected () const
+{
+  return client->IsConnected ();
 }
 
 const std::string&

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -145,6 +145,13 @@ private:
   bool handleIq (const gloox::IQ& iq) override;
   void handleIqID (const gloox::IQ& iq, int context) override;
 
+protected:
+
+  /**
+   * When disconnected, we clean up our notifications.
+   */
+  void HandleDisconnect () override;
+
 public:
 
   explicit IqAnsweringClient (const std::string& v, RpcServer& b,
@@ -291,6 +298,12 @@ Server::IqAnsweringClient::AddNotification (std::unique_ptr<WaiterThread> upd)
   return node;
 }
 
+void
+Server::IqAnsweringClient::HandleDisconnect ()
+{
+  ClearNotifications ();
+}
+
 Server::Server (const std::string& v, RpcServer& b)
   : version(v), backend(b)
 {}
@@ -325,7 +338,6 @@ Server::Disconnect ()
   if (client == nullptr)
     return;
 
-  client->ClearNotifications ();
   client->Disconnect ();
   client.reset ();
 }

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -84,14 +84,20 @@ public:
 
   /**
    * Connects to XMPP with the given priority.  Starts processing
-   * requests once the connection is established.
+   * requests once the connection is established.  Returns false if the
+   * connection failed.
    */
-  void Connect (int priority);
+  bool Connect (int priority);
 
   /**
    * Disconnects the XMPP client and stops processing requests.
    */
   void Disconnect ();
+
+  /**
+   * Returns true if the server is connected.
+   */
+  bool IsConnected () const;
 
 };
 

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -39,12 +39,6 @@ private:
 
   class IqAnsweringClient;
 
-  /** The version string to report.  */
-  const std::string version;
-
-  /** The backing RpcServer instance.  */
-  RpcServer& backend;
-
   /**
    * The XMPP client instance (which is a class defined only in the source
    * file and thus referenced here by pointer).
@@ -56,7 +50,8 @@ private:
 
 public:
 
-  explicit Server (const std::string& v, RpcServer& b);
+  explicit Server (const std::string& version, RpcServer& backend,
+                   const std::string& jid, const std::string& password);
   ~Server ();
 
   Server () = delete;
@@ -64,11 +59,10 @@ public:
   void operator= (const Server&) = delete;
 
   /**
-   * Connects to XMPP with the given JID and password.  Starts processing
+   * Connects to XMPP with the given priority.  Starts processing
    * requests once the connection is established.
    */
-  void Connect (const std::string& jid, const std::string& password,
-                int priority);
+  void Connect (int priority);
 
   /**
    * Adds a pubsub service that can be used for notifications on the XMPP

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -48,6 +48,14 @@ private:
   /** Whether or not we have a pubsub service.  */
   bool hasPubSub = false;
 
+  /**
+   * Returns the pubsub node for a given notification type.  This is used
+   * in tests.
+   */
+  const std::string& GetNotificationNode (const std::string& type) const;
+
+  friend class ServerTests;
+
 public:
 
   explicit Server (const std::string& version, RpcServer& backend,
@@ -59,30 +67,31 @@ public:
   void operator= (const Server&) = delete;
 
   /**
-   * Connects to XMPP with the given priority.  Starts processing
-   * requests once the connection is established.
-   */
-  void Connect (int priority);
-
-  /**
    * Adds a pubsub service that can be used for notifications on the XMPP
    * server we are connected to.
    */
   void AddPubSub (const std::string& service);
 
   /**
-   * Disconnects the XMPP client and stops processing requests.
-   */
-  void Disconnect ();
-
-  /**
    * Starts serving a new notification on the server.  This must only be called
    * if we have a pubsub service enabled.
    *
-   * Returns the pubsub node that has been created for updates on this
-   * notification type.
+   * If the client is connected already, then this enables the new notification
+   * right away.  Otherwise the notification will be enabled once the client
+   * gets connected (and later again if it reconnects).
    */
-  std::string AddNotification (std::unique_ptr<WaiterThread> upd);
+  void AddNotification (std::unique_ptr<WaiterThread> upd);
+
+  /**
+   * Connects to XMPP with the given priority.  Starts processing
+   * requests once the connection is established.
+   */
+  void Connect (int priority);
+
+  /**
+   * Disconnects the XMPP client and stops processing requests.
+   */
+  void Disconnect ();
 
 };
 

--- a/src/server_tests.cpp
+++ b/src/server_tests.cpp
@@ -154,7 +154,9 @@ protected:
   ServerTests ()
     : XmppClient(JIDWithoutResource (GetTestAccount (accClient)),
                  GetTestAccount (accClient).password),
-      server(SERVER_VERSION, backend)
+      server(SERVER_VERSION, backend,
+             JIDWithResource (GetTestAccount (accServer), SERVER_RES).full (),
+             GetTestAccount (accServer).password)
   {
     RunWithClient ([] (gloox::Client& c)
       {
@@ -165,9 +167,7 @@ protected:
         c.registerStanzaExtension (new SupportedNotifications ());
       });
 
-    server.Connect (
-        JIDWithResource (GetTestAccount (accServer), SERVER_RES).full (),
-        GetTestAccount (accServer).password, 0);
+    server.Connect (0);
     Connect (0);
   }
 

--- a/src/waiterthread.cpp
+++ b/src/waiterthread.cpp
@@ -90,6 +90,14 @@ WaiterThread::GetCurrentState () const
 }
 
 void
+WaiterThread::ClearUpdateHandler ()
+{
+  std::lock_guard<std::mutex> lock(mut);
+  cb = UpdateHandler ();
+  CHECK (!cb);
+}
+
+void
 WaiterThread::SetUpdateHandler (const UpdateHandler& h)
 {
   std::lock_guard<std::mutex> lock(mut);

--- a/src/waiterthread.hpp
+++ b/src/waiterthread.hpp
@@ -149,6 +149,11 @@ public:
   Json::Value GetCurrentState () const;
 
   /**
+   * Removes the update handler.
+   */
+  void ClearUpdateHandler ();
+
+  /**
    * Sets / replaces the handler for updates.
    */
   void SetUpdateHandler (const UpdateHandler& h);

--- a/src/xmppclient_tests.cpp
+++ b/src/xmppclient_tests.cpp
@@ -1,6 +1,6 @@
 /*
     Charon - a transport system for GSP data
-    Copyright (C) 2019  Autonomous Worlds Ltd
+    Copyright (C) 2019-2020  Autonomous Worlds Ltd
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -40,7 +40,7 @@ namespace
  * XMPP client connection for use in testing.  It can send messages and
  * receive them (passing on to a ReceivedMessages instance).
  */
-class TestXmppClient : private XmppClient, private gloox::MessageHandler
+class TestXmppClient : public XmppClient, private gloox::MessageHandler
 {
 
 private:
@@ -106,6 +106,30 @@ using XmppClientTests = testing::Test;
 TEST_F (XmppClientTests, Connecting)
 {
   TestXmppClient client(GetTestAccount (0));
+  EXPECT_TRUE (client.IsConnected ());
+}
+
+TEST_F (XmppClientTests, FailedConnection)
+{
+  XmppClient wrongPassword(JIDWithoutResource (GetTestAccount (0)), "wrong");
+  EXPECT_FALSE (wrongPassword.Connect (0));
+  EXPECT_FALSE (wrongPassword.IsConnected ());
+
+  XmppClient invalidServer(gloox::JID ("test@invalid.server"), "password");
+  EXPECT_FALSE (invalidServer.Connect (0));
+  EXPECT_FALSE (invalidServer.IsConnected ());
+}
+
+TEST_F (XmppClientTests, Reconnection)
+{
+  TestXmppClient client(GetTestAccount (0));
+  ASSERT_TRUE (client.IsConnected ());
+
+  client.Disconnect ();
+  ASSERT_FALSE (client.IsConnected ());
+
+  EXPECT_TRUE (client.Connect (0));
+  ASSERT_TRUE (client.IsConnected ());
 }
 
 TEST_F (XmppClientTests, Messages)

--- a/test/xmpp_restart.py
+++ b/test/xmpp_restart.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+#   Charon - a transport system for GSP data
+#   Copyright (C) 2019-2020  Autonomous Worlds Ltd
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Tests how Charon handles XMPP server restarts.  Since this test needs
+the XMPP server to be restarted in the middle, it has to be run manually
+(and the restart needs to be done manually).
+"""
+
+import testcase
+
+import waitforchange
+
+import threading
+import time
+
+
+class Methods (waitforchange.Methods):
+
+  def echo (self, val):
+    return val
+
+
+class UpdateSpammer (threading.Thread):
+  """
+  Thread that "spams" updates and calls on our Charon server (state changes).
+  This is run while the XMPP server is restarted, to make sure that Charon
+  still handles the disconnect and reconnect gracefully even while things
+  are going on as they might in a real-world situation.
+  """
+
+  def __init__ (self, backend):
+    super ().__init__ ()
+    self.backend = backend
+    self.lock = threading.Lock ()
+    self.shouldStop = False
+
+  def run (self):
+    cnt = 0
+    while True:
+      with self.lock:
+        if self.shouldStop:
+          return
+
+        self.backend.update ("ignored %d" % cnt)
+        cnt += 1
+
+      # Without holding the lock, sleep a little time to give other parts
+      # time to process.
+      time.sleep (0.001)
+
+  def stop (self):
+    with self.lock:
+      self.shouldStop = True
+    self.join ()
+
+
+def runTest (t, backend, c, nonce):
+  """
+  Runs basic tests that the Charon connection is up and working.  This sends
+  a normal RPC and also triggers a waitforchange update.
+  """
+
+  waiterRpc = c.createRpc ()
+  w = waitforchange.Waiter (waiterRpc.waitforchange, "")
+
+  t.assertEqual (c.rpc.echo (nonce), nonce)
+
+  w.assertRunning ()
+  backend.update (nonce)
+  t.assertEqual (w.wait (), nonce)
+
+
+with Methods () as backend, \
+     testcase.Fixture (["echo"], waitforchange=True) as t, \
+     t.runServer (backend):
+
+  # FIXME: Also keep the client around once it supports reconnects
+  # to test that as well.
+  with t.runClient () as c:
+    t.mainLogger.info ("Initial Charon test...")
+    runTest (t, backend, c, "foo")
+
+  spammer = UpdateSpammer (backend)
+  spammer.start ()
+
+  input ("Restart the XMPP server and press Enter to continue...\n")
+
+  spammer.stop ()
+
+  with t.runClient () as c:
+    t.mainLogger.info ("Testing Charon after the restart...")
+    runTest (t, backend, c, "bar")

--- a/util/server.cpp
+++ b/util/server.cpp
@@ -104,10 +104,8 @@ main (int argc, char** argv)
       backend.AllowMethod (m);
     }
 
-  LOG (INFO) << "Connecting server to XMPP as " << FLAGS_server_jid;
   charon::Server srv(FLAGS_backend_version, backend,
                      FLAGS_server_jid, FLAGS_password);
-  srv.Connect (FLAGS_priority);
 
   if (FLAGS_pubsub_service.empty ())
     {
@@ -129,6 +127,9 @@ main (int argc, char** argv)
   if (FLAGS_waitforpendingchange)
     srv.AddNotification (NewWaiter<charon::PendingChangeNotification> (
         "waitforpendingchange"));
+
+  LOG (INFO) << "Connecting server to XMPP as " << FLAGS_server_jid;
+  srv.Connect (FLAGS_priority);
 
   while (true)
     std::this_thread::sleep_for (std::chrono::seconds (1));

--- a/util/server.cpp
+++ b/util/server.cpp
@@ -54,6 +54,12 @@ DEFINE_bool (waitforpendingchange, false,
              "If true, enable waitforpendingchange updates");
 
 /**
+ * Time between connection retries if the server gets disconnected.  This is
+ * also the general sleep time in the main loop.
+ */
+const auto RECONNECT_INTERVAL = std::chrono::seconds (5);
+
+/**
  * Constructs a WaiterThread instance for the given notification type, using
  * the given RPC method as long-polling backend call.
  */
@@ -128,11 +134,15 @@ main (int argc, char** argv)
     srv.AddNotification (NewWaiter<charon::PendingChangeNotification> (
         "waitforpendingchange"));
 
-  LOG (INFO) << "Connecting server to XMPP as " << FLAGS_server_jid;
-  srv.Connect (FLAGS_priority);
-
   while (true)
-    std::this_thread::sleep_for (std::chrono::seconds (1));
+    {
+      if (!srv.IsConnected ())
+        {
+          LOG (INFO) << "Connecting server to XMPP as " << FLAGS_server_jid;
+          srv.Connect (FLAGS_priority);
+        }
+      std::this_thread::sleep_for (RECONNECT_INTERVAL);
+    }
 
   return EXIT_SUCCESS;
 }

--- a/util/server.cpp
+++ b/util/server.cpp
@@ -105,8 +105,9 @@ main (int argc, char** argv)
     }
 
   LOG (INFO) << "Connecting server to XMPP as " << FLAGS_server_jid;
-  charon::Server srv(FLAGS_backend_version, backend);
-  srv.Connect (FLAGS_server_jid, FLAGS_password, FLAGS_priority);
+  charon::Server srv(FLAGS_backend_version, backend,
+                     FLAGS_server_jid, FLAGS_password);
+  srv.Connect (FLAGS_priority);
 
   if (FLAGS_pubsub_service.empty ())
     {


### PR DESCRIPTION
Charon already handles it quite well if the Charon server goes down, but it assumes pretty much that the XMPP server was alright the entire time.

With this set of changes, we make the XMPP client and Charon server more resilient against errors on the XMPP side, and in particular it being disconnected by the XMPP server (e.g. because the server shuts down).  A `Server` can now just be connected/disconnected multiple times after being set up with notifications and everything.  We use that in `charon-server` to make it retry connecting every five seconds if it gets disconnected.