### PR TITLE
Auto-connect the Charon client as needed

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -834,10 +834,14 @@ Client::Client (const std::string& srv, const std::string& v,
 Client::~Client () = default;
 
 void
-Client::Connect (const int priority)
+Client::Connect ()
 {
   CHECK (impl != nullptr);
-  impl->Connect (priority);
+
+  /* We always connect with priority -1, because the client will never want
+     to receive any messages for the bare JID.  It only communicates with
+     its full JID.  */
+  impl->Connect (-1);
 }
 
 void

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -57,12 +57,6 @@ private:
   Duration timeout;
 
   /**
-   * Notification types that we should listen to.  This is the place where
-   * the instances are held and owned.
-   */
-  std::map<std::string, std::unique_ptr<NotificationType>> notifications;
-
-  /**
    * The class implementing the main logic.  Its internals depend on private
    * libraries like gloox, so that the definition is not exposed in the header.
    */
@@ -73,9 +67,13 @@ public:
   /**
    * Constructs the client instance (without connecting it).  Any requests
    * made (after the instance is connected) will be forwarded to the given
-   * JID for reply.
+   * JID for reply.#
+   *
+   * This already fixes the JID and password for the client's XMPP connection
+   * as well, but does not yet actually connect to the XMPP network.
    */
-  explicit Client (const std::string& srv, const std::string& v);
+  explicit Client (const std::string& srv, const std::string& v,
+                   const std::string& jid, const std::string& password);
 
   ~Client ();
 
@@ -95,11 +93,9 @@ public:
   }
 
   /**
-   * Connects to XMPP with the given JID and password.  Starts a thread
-   * that processes any data we receive.
+   * Connects to XMPP and starts a thread that processes any data we receive.
    */
-  void Connect (const std::string& jid, const std::string& password,
-                int priority);
+  void Connect (int priority);
 
   /**
    * Disconnects the XMPP client and stops processing data.

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -95,7 +95,7 @@ public:
   /**
    * Connects to XMPP and starts a thread that processes any data we receive.
    */
-  void Connect (int priority);
+  void Connect ();
 
   /**
    * Disconnects the XMPP client and stops processing data.

--- a/src/client_tests.cpp
+++ b/src/client_tests.cpp
@@ -219,6 +219,11 @@ TEST_F (ClientServerDiscoveryTests, IgnoresOtherServer)
 
 TEST_F (ClientServerDiscoveryTests, MultipleThreads)
 {
+  /* Disconnect the client first, so that it will have to auto-connect
+     on demand and we can test that this works even with many concurrent
+     threads triggering it.  */
+  client.Disconnect ();
+
   client.SetTimeout (2 * PONG_DELAY);
 
   std::vector<std::thread> threads;
@@ -252,6 +257,15 @@ TEST_F (ClientServerDiscoveryTests, DisconnectClearsServerJid)
   client.Disconnect ();
   client.Connect ();
   EXPECT_EQ (client.GetServerResource (), "other");
+}
+
+TEST_F (ClientServerDiscoveryTests, ConnectionFailure)
+{
+  Client other(JIDWithoutResource (GetTestAccount (accServer)).bare (),
+               SERVER_VERSION,
+               JIDWithoutResource (GetTestAccount (accClient)).full (),
+               "wrong password");
+  EXPECT_EQ (other.GetServerResource (), "");
 }
 
 /* ************************************************************************** */

--- a/src/client_tests.cpp
+++ b/src/client_tests.cpp
@@ -235,6 +235,25 @@ TEST_F (ClientServerDiscoveryTests, MultipleThreads)
   ExpectClientPresence ();
 }
 
+TEST_F (ClientServerDiscoveryTests, DisconnectClearsServerJid)
+{
+  client.SetTimeout (2 * PONG_DELAY);
+  EXPECT_EQ (client.GetServerResource (), SERVER_RES);
+
+  /* Now we start a second server with higher priority (and no pong delay),
+     which will be selected over the custom server if reselected.  */
+  TestBackend backend;
+  Server srv(SERVER_VERSION, backend,
+             JIDWithResource (GetTestAccount (accServer), "other").full (),
+             GetTestAccount (accServer).password);
+  srv.Connect (100);
+
+  EXPECT_EQ (client.GetServerResource (), SERVER_RES);
+  client.Disconnect ();
+  client.Connect ();
+  EXPECT_EQ (client.GetServerResource (), "other");
+}
+
 /* ************************************************************************** */
 
 /**

--- a/src/client_tests.cpp
+++ b/src/client_tests.cpp
@@ -152,7 +152,7 @@ protected:
         c.registerPresenceHandler (this);
       });
 
-    client.Connect (0);
+    client.Connect ();
     Connect (0);
   }
 
@@ -303,7 +303,7 @@ protected:
   void
   ConnectClient ()
   {
-    client.Connect (0);
+    client.Connect ();
   }
 
   /**
@@ -371,7 +371,7 @@ TEST_F (ClientRpcForwardingTests, CallTimeout)
 TEST_F (ClientRpcForwardingTests, Reconnect)
 {
   client.Disconnect ();
-  client.Connect (0);
+  client.Connect ();
 
   auto srv = ConnectServer ();
   EXPECT_EQ (client.ForwardMethod ("echo", ParseJson (R"(["foo"])")), "foo");
@@ -654,7 +654,7 @@ TEST_F (ClientNotificationTests, Reconnect)
   ConnectClient ({"foo"});
 
   client.Disconnect ();
-  client.Connect (0);
+  client.Connect ();
 
   auto s = ConnectServer ();
   s->AddPubSub (GetServerConfig ().pubsub);

--- a/src/xmppclient.cpp
+++ b/src/xmppclient.cpp
@@ -164,7 +164,8 @@ XmppClient::Receive ()
       return true;
 
     default:
-      LOG (FATAL) << "Receive error for " << jid.full () << ": " << res;
+      LOG (ERROR) << "Receive error for " << jid.full () << ": " << res;
+      return true;
     }
 }
 

--- a/util/client.cpp
+++ b/util/client.cpp
@@ -221,7 +221,8 @@ main (int argc, char** argv)
 
   LOG (INFO) << "Using " << FLAGS_server_jid << " as server";
   LOG (INFO) << "Requiring backend version " << FLAGS_backend_version;
-  charon::Client client(FLAGS_server_jid, FLAGS_backend_version);
+  charon::Client client(FLAGS_server_jid, FLAGS_backend_version,
+                        FLAGS_client_jid, FLAGS_password);
 
   LOG (INFO) << "Listening for local RPCs on port " << FLAGS_port;
   jsonrpc::HttpServer httpServer(FLAGS_port);
@@ -252,7 +253,7 @@ main (int argc, char** argv)
     }
 
   LOG (INFO) << "Connecting client to XMPP as " << FLAGS_client_jid;
-  client.Connect (FLAGS_client_jid, FLAGS_password, -1);
+  client.Connect (-1);
 
   if (FLAGS_detect_server)
     {

--- a/util/client.cpp
+++ b/util/client.cpp
@@ -253,7 +253,7 @@ main (int argc, char** argv)
     }
 
   LOG (INFO) << "Connecting client to XMPP as " << FLAGS_client_jid;
-  client.Connect (-1);
+  client.Connect ();
 
   if (FLAGS_detect_server)
     {


### PR DESCRIPTION
This is a follow-up for #11.  Also the Charon client is now made more resilient against XMPP connection issues.  It handles it well if disconnected, and will just attempt to reconnect whenever needed, i.e. when the next RPC comes in (just like what it does already for server reselection).